### PR TITLE
Throw custom pyramid swagger exceptions instead of pyramid httpexception...

### DIFF
--- a/pyramid_swagger/exceptions.py
+++ b/pyramid_swagger/exceptions.py
@@ -2,9 +2,9 @@
 from pyramid.httpexceptions import HTTPClientError, HTTPInternalServerError
 
 
-class PyramidSwaggerRequestValidationError(HTTPClientError):
+class RequestValidationError(HTTPClientError):
     pass
 
 
-class PyramidSwaggerResponseValidationError(HTTPInternalServerError):
+class ResponseValidationError(HTTPInternalServerError):
     pass

--- a/pyramid_swagger/tween.py
+++ b/pyramid_swagger/tween.py
@@ -8,8 +8,8 @@ import re
 import jsonschema.exceptions
 import simplejson
 from jsonschema.validators import Draft3Validator, Draft4Validator
-from pyramid_swagger.exceptions import PyramidSwaggerRequestValidationError
-from pyramid_swagger.exceptions import PyramidSwaggerResponseValidationError
+from pyramid_swagger.exceptions import RequestValidationError
+from pyramid_swagger.exceptions import ResponseValidationError
 from .ingest import compile_swagger_schema
 from .model import PathNotMatchedError
 
@@ -79,7 +79,7 @@ def validation_tween_factory(handler, registry):
                 request)
         except PathNotMatchedError as exc:
             if settings.validate_path:
-                raise PyramidSwaggerRequestValidationError(str(exc))
+                raise RequestValidationError(str(exc))
             else:
                 return handler(request)
 
@@ -158,8 +158,7 @@ def should_exclude_path(exclude_path_regexes, path):
 
 
 def _validate_request(route_mapper, request, schema_data, resolver):
-    """ Validates a request and raises a PyramidSwaggerRequestValidationError
-    on failure.
+    """ Validates a request and raises a RequestValidationError on failure.
 
     :param request: the request object to validate
     :type request: Pyramid request object passed into a view
@@ -179,12 +178,11 @@ def _validate_request(route_mapper, request, schema_data, resolver):
     except jsonschema.exceptions.ValidationError as exc:
         # This will alter our stack trace slightly, but Pyramid knows how
         # to render it. And the real value is in the message anyway.
-        raise PyramidSwaggerRequestValidationError(str(exc))
+        raise RequestValidationError(str(exc))
 
 
 def _validate_response(response, schema_data, schema_resolver):
-    """ Validates a response and raises a PyramidSwaggerResponseValidationError
-    on failure.
+    """ Validates a response and raises a ResponseValidationError on failure.
 
     :param response: the response object to validate
     :type response: Pyramid response object passed into a view
@@ -203,7 +201,7 @@ def _validate_response(response, schema_data, schema_resolver):
     except jsonschema.exceptions.ValidationError as exc:
         # This will alter our stack trace slightly, but Pyramid knows how
         # to render it and the real value is in the message anyway.
-        raise PyramidSwaggerResponseValidationError(str(exc))
+        raise ResponseValidationError(str(exc))
 
 
 def cast_request_param(request_schema, param_name, param_value):
@@ -311,7 +309,7 @@ def validate_outgoing_response(response, schema_map, resolver):
 def prepare_body(response):
     # content_type and charset must both be set to access response.text
     if response.content_type is None or response.charset is None:
-        raise PyramidSwaggerResponseValidationError(
+        raise ResponseValidationError(
             'Response validation error: Content-Type and charset must be set'
         )
 

--- a/tests/acceptance/response_test.py
+++ b/tests/acceptance/response_test.py
@@ -8,7 +8,7 @@ from .request_test import test_app
 from pyramid.config import Configurator
 from pyramid.registry import Registry
 from pyramid.response import Response
-from pyramid_swagger.exceptions import PyramidSwaggerResponseValidationError
+from pyramid_swagger.exceptions import ResponseValidationError
 from pyramid_swagger.tween import validation_tween_factory
 from webtest import AppError
 
@@ -58,7 +58,7 @@ def test_response_validation_enabled_by_default():
         body=simplejson.dumps({'raw_response': 'foo'}),
         headers={'Content-Type': 'application/json; charset=UTF-8'},
     )
-    with pytest.raises(PyramidSwaggerResponseValidationError):
+    with pytest.raises(ResponseValidationError):
         _validate_against_tween(request, response=response)
 
 
@@ -74,7 +74,7 @@ def test_500_when_response_is_missing_required_field():
         body=simplejson.dumps({'raw_response': 'foo'}),
         headers={'Content-Type': 'application/json; charset=UTF-8'},
     )
-    with pytest.raises(PyramidSwaggerResponseValidationError):
+    with pytest.raises(ResponseValidationError):
         _validate_against_tween(request, response=response)
 
 
@@ -106,7 +106,7 @@ def test_500_when_response_arg_is_wrong_type():
         }),
         headers={'Content-Type': 'application/json; charset=UTF-8'},
     )
-    with pytest.raises(PyramidSwaggerResponseValidationError):
+    with pytest.raises(ResponseValidationError):
         _validate_against_tween(request, response=response)
 
 
@@ -119,7 +119,7 @@ def test_500_for_bad_validated_array_response():
         body=simplejson.dumps([{"enum_value": "bad_enum_value"}]),
         headers={'Content-Type': 'application/json; charset=UTF-8'},
     )
-    with pytest.raises(PyramidSwaggerResponseValidationError):
+    with pytest.raises(ResponseValidationError):
         _validate_against_tween(request, response=response)
 
 

--- a/tests/tween_test.py
+++ b/tests/tween_test.py
@@ -8,7 +8,7 @@ from mock import Mock
 from pyramid.response import Response
 
 
-from pyramid_swagger.exceptions import PyramidSwaggerResponseValidationError
+from pyramid_swagger.exceptions import ResponseValidationError
 from pyramid_swagger.tween import DEFAULT_EXCLUDED_PATHS
 from pyramid_swagger.tween import get_exclude_paths
 from pyramid_swagger.tween import load_settings
@@ -45,7 +45,7 @@ def test_exclude_path_with_old_setting():
 
 
 def test_response_charset_missing_raises_5xx():
-    with pytest.raises(PyramidSwaggerResponseValidationError):
+    with pytest.raises(ResponseValidationError):
         prepare_body(
             Response(content_type='foo')
         )


### PR DESCRIPTION
We want to throw custom pyramid swagger exceptions for request and response validation so that we can catch them inside our tween. Within our tween, we didn't want to catch for HTTPInternalServerError or HTTPClientServerError as they're too broad (i.e, these can also be raised from pyramid, and not just pyramid_swagger). 
