### PR TITLE
Address failing pypi deploys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,11 @@ deploy:
   password:
     secure: cNExm/7XrxdF8c/m+EpXDVObR5h4FJnGCVhE0sMKR6VbjUQU/WAYPdy3r2mfF1xeJH9aOxzOa1eBb60B8965GRgJu1lzQB6NwjDDEw0mVHRRxEEpnpQdKi2DOCMmP2W/aFuPYtd2DlZA3ddd1EOvNbgJeUisgy1dLFcl4KbACn8=
   on:
+    # all_branches is a hack for https://github.com/travis-ci/travis-ci/issues/1675.
+    # NOTE: Only tag master, and only when you want to publish to pypi!
+    # After this issue gets fixed, we can go back to deploying on tagged master
+    # commits only.
+    all_branches: true
     tags: true
     repo: striglia/pyramid_swagger
-    branch: master
     distributions: "sdist bdist_wheel"

--- a/pyramid_swagger/__about__.py
+++ b/pyramid_swagger/__about__.py
@@ -16,7 +16,7 @@ __uri__ = "https://github.com/striglia/pyramid_swagger"
 __version__ = "1.3.0"
 
 __author__ = "Scott Triglia"
-__email__ = "striglia@yelp.com"
+__email__ = "scott.triglia@gmail.com"
 
-__license__ = "Copyright 2013-2014 Yelp"
-__copyright__ = "Copyright 2013-2014 Yelp"
+__license__ = "BSD 3-clause"
+__copyright__ = "Copyright 2014 Scott Triglia"


### PR DESCRIPTION
Fixes #76 

Not pretty, but I think the automation is worth it. We can back this out after that issue is resolved properly.

Since 1.3.0 is not covered by this, I deployed it to pypi manually and it now appears at https://pypi.python.org/pypi/pyramid_swagger.