### PR TITLE
Feature: exclude routes from validation

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -39,6 +39,9 @@ A few relevant settings for your `Pyramid .ini file <http://docs.pylonsproject.o
         # Default: [r'^/static/?', r'^/api-docs/?']
         pyramid_swagger.exclude_paths = [r'^/static/?', r'^/api-docs/?']
 
+        # Exclude pyramid routes from validation. Accepts a list of strings
+        pyramid_swagger.exclude_routes = ['catchall', 'no-validation']
+
         # Path to contextmanager to handle request/response validation
         # exceptions. This should be a dotted python name as per
         # http://docs.pylonsproject.org/projects/pyramid/en/latest/glossary.html#term-dotted-python-name

--- a/tests/acceptance/response_test.py
+++ b/tests/acceptance/response_test.py
@@ -7,11 +7,13 @@ import pytest
 import simplejson
 from .request_test import test_app
 from pyramid.config import Configurator
+from pyramid.interfaces import IRoutesMapper
 from pyramid.registry import Registry
 from pyramid.response import Response
 from pyramid_swagger.exceptions import ResponseValidationError
 from pyramid_swagger.ingest import compile_swagger_schema
 from pyramid_swagger.tween import validation_tween_factory
+from pyramid.urldispatch import RoutesMapper
 from webtest import AppError
 
 
@@ -35,6 +37,7 @@ def get_registry(settings):
     config = Configurator(registry=registry)
     if getattr(registry, 'settings', None) is None:
         config._set_settings(settings)
+    registry.registerUtility(RoutesMapper(), IRoutesMapper)
     config.commit()
     return registry
 

--- a/tests/tween_test.py
+++ b/tests/tween_test.py
@@ -13,6 +13,7 @@ from pyramid_swagger.tween import DEFAULT_EXCLUDED_PATHS
 from pyramid_swagger.tween import get_exclude_paths
 from pyramid_swagger.tween import prepare_body
 from pyramid_swagger.tween import should_exclude_path
+from pyramid_swagger.tween import should_exclude_route
 from pyramid_swagger.tween import validate_outgoing_response
 
 
@@ -61,6 +62,26 @@ def test_response_charset_missing_raises_5xx():
         prepare_body(
             Response(content_type='foo')
         )
+
+
+@pytest.fixture
+def mock_route_info():
+    class MockRoute(object):
+        name = 'route-one'
+
+    return {'route': MockRoute}
+
+
+def test_should_exclude_route(mock_route_info):
+    assert should_exclude_route(set(['route-one', 'two']), mock_route_info)
+
+
+def test_should_exclude_route_no_matched_route(mock_route_info):
+    assert not should_exclude_route(set(['foo', 'two']), mock_route_info)
+
+
+def test_should_exclude_route_no_route():
+    assert not should_exclude_route(set(['foo', 'two']), {'route': None})
 
 
 def test_validation_skips_path_properly():


### PR DESCRIPTION
Currently requests can be excluded by path, or by disabling all path validation.

This PR adds support for excluding some routes from validation as another option before disabling all path validation.

y-m uses a single fallback route for legacy routing, so this will allow us to use path validation for all pyramid views, and exclude legacy views.