### PR TITLE
Bump to 1.5.0-dev

### DIFF
--- a/pyramid_swagger/__about__.py
+++ b/pyramid_swagger/__about__.py
@@ -13,7 +13,7 @@ __title__ = "pyramid_swagger"
 __summary__ = "Swagger tools for use in pyramid webapps"
 __uri__ = "https://github.com/striglia/pyramid_swagger"
 
-__version__ = "1.4.1"
+__version__ = "1.5.0-dev"
 
 __author__ = "Scott Triglia"
 __email__ = "scott.triglia@gmail.com"


### PR DESCRIPTION
See https://www.python.org/dev/peps/pep-0440/#developmental-releases

Bumping us to 1.5.0-dev in anticipation of a 1.5 release. Note the lack of a tag.