### PR TITLE
Expose Validators instead of schemas and resolvers

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,9 +13,9 @@ Changelog
 * Added ``generate_resource_listing`` configuration option to allow
   pyramid_swagger to generate the ``apis`` section of the resource listing.
 * Bug fix for issues relating to ``void`` responses (See `Issue 79`_)
+* Added support for header validation.
 
 .. _Issue 79: https://github.com/striglia/pyramid_swagger/issues/79
-
 
 1.4.0 (2015-01-27)
 ++++++++++++++++++

--- a/pyramid_swagger/ingest.py
+++ b/pyramid_swagger/ingest.py
@@ -121,8 +121,8 @@ def compile_swagger_schema(schema_dir, resource_listing):
     :returns: a SwaggerSchema object
     """
     mapping = build_schema_mapping(schema_dir, resource_listing)
-    schema_resolvers = ingest_resources(mapping, schema_dir)
-    return SwaggerSchema(resource_listing, mapping, schema_resolvers)
+    resource_validators = ingest_resources(mapping, schema_dir)
+    return SwaggerSchema(resource_listing, mapping, resource_validators)
 
 
 def validate_swagger_schema(schema_dir, resource_listing):
@@ -161,8 +161,8 @@ def ingest_resources(mapping, schema_dir):
     :type mapping: dict
     :param schema_dir: the directory schema files live inside
     :type schema_dir: string
-    :returns: A list of :class:`pyramid_swagger.load_schema.SchemaAndResolver`
-        objects
+    :returns: A list of mapping from :class:`RequestMatcher` to
+        :class:`ValidatorMap`
     """
     ingested_resources = []
     for name, filepath in mapping.items():

--- a/pyramid_swagger/load_schema.py
+++ b/pyramid_swagger/load_schema.py
@@ -55,7 +55,8 @@ def build_param_schema(schema, param_type):
         return {
             'type': 'object',
             'properties': properties,
-            'additionalProperties': False,
+            # Allow extra headers
+            'additionalProperties': param_type == 'header',
         }
     else:
         return None

--- a/pyramid_swagger/load_schema.py
+++ b/pyramid_swagger/load_schema.py
@@ -55,7 +55,8 @@ def build_param_schema(schema, param_type):
         return {
             'type': 'object',
             'properties': properties,
-            # Allow extra headers
+            # Allow extra headers. Most HTTP requests will have headers which
+            # are outside the scope of the spec (like `Host`, or `User-Agent`)
             'additionalProperties': param_type == 'header',
         }
     else:
@@ -166,6 +167,15 @@ class ValidatorMap(namedtuple('_VMap', 'query path headers body response')):
 
 
 class SchemaValidator(object):
+    """A Validator used by :mod:`pyramid_swagger.tween` to validate a
+    field from the request or response.
+
+    :param schema: a :class:`dict` jsonschema that was used by the
+        validator
+    :param valdiator: a Validator which a func:`validate` method
+        for validating a field from a request or response. This
+        will often be a :class:`jsonschema.validator.Validator`.
+    """
 
     def __init__(self, schema, validator):
         self.schema = schema
@@ -178,6 +188,9 @@ class SchemaValidator(object):
             validator_class(schema, resolver=resolver, types=EXTENDED_TYPES))
 
     def validate(self, values):
+        """Validate a :class:`dict` of values. If `self.schema` is falsy this
+        is a noop.
+        """
         if not self.schema:
             return
         self.validator.validate(values)

--- a/pyramid_swagger/load_schema.py
+++ b/pyramid_swagger/load_schema.py
@@ -8,6 +8,15 @@ from collections import namedtuple
 
 import simplejson
 from jsonschema import RefResolver
+from jsonschema.validators import Draft3Validator, Draft4Validator
+
+from pyramid_swagger.model import partial_path_match
+
+
+EXTENDED_TYPES = {
+    'float': (float,),
+    'int': (int,),
+}
 
 
 def build_param_schema(schema, param_type):
@@ -129,44 +138,82 @@ def get_model_resolver(schema):
     return RefResolver('', '', models)
 
 
-class SchemaMap(namedtuple(
-    'SchemaMap', [
-        'request_query_schema',
-        'request_path_schema',
-        'request_header_schema',
-        'request_body_schema',
-        'response_body_schema'
-    ])):
+class ValidatorMap(namedtuple('_VMap', 'query path headers body response')):
     """
-    A SchemaMap contains a mapping from incoming paths to schemas for request
-    queries, request bodies, and responses. This requires some precomputation
-    but means we can do fast query-time validation without having to walk over
-    the schema.
+    A data object with validators for each part of the request and response
+    objects. Each field is a :class:`SchemaValidator`.
     """
     __slots__ = ()
 
     @classmethod
-    def from_operation(cls, operation, models):
+    def from_operation(cls, operation, models, resolver):
+        args = []
+        for schema, validator in [
+            (build_param_schema(operation, 'query'), Draft3Validator),
+            (build_param_schema(operation, 'path'), Draft3Validator),
+            (build_param_schema(operation, 'header'), Draft3Validator),
+            (extract_body_schema(operation, models), Draft4Validator),
+            (extract_response_body_schema(operation, models),
+                Draft4Validator),
+        ]:
+            args.append(SchemaValidator.from_schema(
+                schema,
+                resolver,
+                validator))
+
+        return cls(*args)
+
+
+class SchemaValidator(object):
+
+    def __init__(self, schema, validator):
+        self.schema = schema
+        self.validator = validator
+
+    @classmethod
+    def from_schema(cls, schema, resolver, validator_class):
         return cls(
-            build_param_schema(operation, 'query'),
-            build_param_schema(operation, 'path'),
-            build_param_schema(operation, 'header'),
-            extract_body_schema(operation, models),
-            extract_response_body_schema(operation, models),
-        )
+            schema,
+            validator_class(schema, resolver=resolver, types=EXTENDED_TYPES))
+
+    def validate(self, values):
+        if not self.schema:
+            return
+        self.validator.validate(values)
 
 
-def build_request_to_schemas_map(schema):
-    """Take the swagger schema and build a map from incoming path to a
-    jsonschema for requests and responses."""
+def build_request_to_validator_map(schema, resolver):
+    """Build a mapping from :class:`RequestMatcher` to :class:`ValidatorMap`
+    for each operation in the API spec. This mapping may be used to retrieve
+    the appropriate validators for a request.
+    """
     schema_models = schema.get('models', {})
-    for api in schema['apis']:
-        path = api['path']
-        for operation in api['operations']:
-            # Now that we have the necessary info for this particular
-            # path/method combination, build our dict.
-            key = (path, operation['method'])
-            yield key, SchemaMap.from_operation(operation, schema_models)
+    return dict(
+        (
+            RequestMatcher(api['path'], operation['method']),
+            ValidatorMap.from_operation(operation, schema_models, resolver)
+        )
+        for api in schema['apis']
+        for operation in api['operations']
+    )
+
+
+class RequestMatcher(object):
+    """Match a :class:`pyramid.request.Request` to a swagger Operation"""
+
+    def __init__(self, path, method):
+        self.path = path
+        self.method = method
+
+    def matches(self, request):
+        """
+        :param request: a :class:`pyramid.request.Request`
+        :returns: True if this matcher matches the request, False otherwise
+        """
+        return (
+            partial_path_match(request.path, self.path) and
+            request.method == self.method
+        )
 
 
 # TODO: do this with jsonschema directly
@@ -203,34 +250,13 @@ def extract_validatable_type(type_name, models):
         return {'type': type_name}
 
 
-class SchemaAndResolver(namedtuple(
-        'SAR',
-        ['request_to_schema_map', 'resolver'])):
-    __slots__ = ()
-
-
 def load_schema(schema_path):
-    """Prepare the schema so we can make fast validation comparisons.
+    """Prepare the api specification for request and response validation.
 
-    The prepared schema will be a map:
-        key: (swagger_path, method) e.g. ('/v1/reverse', 'GET')
-        value: a SchemaMap
-
-    For any request, you just need to:
-        1) Validate {k, v for k, v in query.params} against
-            request_query_schema
-        2) Validate request body against request_body_schema
-        3) Validate response body against response_body_schema
-
-        Response and request bodies will need to be transformed as indicated by
-        their content type (e.g. simplejson.loads if you have application/json
-        type).
-
-    :returns: SchemaAndResolver
+    :returns: a mapping from :class:`RequestMatcher` to :class:`ValidatorMap`
+        for every operation in the api specification.
+    :rtype: dict
     """
     with open(schema_path, 'r') as schema_file:
         schema = simplejson.load(schema_file)
-    return SchemaAndResolver(
-        request_to_schema_map=dict(build_request_to_schemas_map(schema)),
-        resolver=get_model_resolver(schema),
-    )
+    return build_request_to_validator_map(schema, get_model_resolver(schema))

--- a/pyramid_swagger/tween.py
+++ b/pyramid_swagger/tween.py
@@ -8,16 +8,10 @@ import re
 
 import jsonschema.exceptions
 import simplejson
-from jsonschema.validators import Draft3Validator, Draft4Validator
 from pyramid_swagger.exceptions import RequestValidationError
 from pyramid_swagger.exceptions import ResponseValidationError
 from .model import PathNotMatchedError
 
-
-EXTENDED_TYPES = {
-    'float': (float,),
-    'int': (int,),
-}
 
 DEFAULT_EXCLUDED_PATHS = [
     r'^/static/?',
@@ -100,10 +94,7 @@ def validation_tween_factory(handler, registry):
         validation_context = _get_validation_context(registry)
 
         try:
-            (
-                schema_data,
-                resolver
-            ) = settings.schema.schema_and_resolver_for_request(request)
+            validator_map = settings.schema.validators_for_request(request)
         except PathNotMatchedError as exc:
             if settings.validate_path:
                 with validation_context(request):
@@ -113,22 +104,14 @@ def validation_tween_factory(handler, registry):
 
         if settings.validate_request:
             with validation_context(request):
-                _validate_request(
-                    (route_info.get('match') or {}).items(),
-                    request,
-                    schema_data,
-                    resolver
-                )
+                route_match = (route_info.get('match') or {}).items()
+                _validate_request(route_match, request, validator_map)
 
         response = handler(request)
 
         if settings.validate_response:
             with validation_context(request, response=response):
-                _validate_response(
-                    response,
-                    schema_data,
-                    resolver
-                )
+                _validate_response(response, validator_map.response)
 
         return response
 
@@ -202,51 +185,18 @@ def should_exclude_route(excluded_routes, route_info):
     )
 
 
-def _validate_request(route_match, request, schema_data, resolver):
-    """Validates a request and raises a
-    :class:`pyramid_swagger.exceptions.RequestValidationError` on failure.
-
-    :param route_match: a dict with all the path params and their values from
-        the request
-    :param route_match: dict
-    :param request: the request object to validate
-    :type request: Pyramid request object passed into a view
-    :param schema_data: our mapping from request data to schemas (see
-        load_schema)
-    :type schema_data: dict
-    :param resolver: the request object to validate
-    :type resolver: Pyramid request object passed into a view
-    """
+def _validate_request(route_match, request, validator_map):
     try:
-        validate_incoming_request(
-            route_match,
-            request,
-            schema_data,
-            resolver
-        )
+        validate_incoming_request(route_match, request, validator_map)
     except jsonschema.exceptions.ValidationError as exc:
         # This will alter our stack trace slightly, but Pyramid knows how
         # to render it. And the real value is in the message anyway.
         raise RequestValidationError(str(exc))
 
 
-def _validate_response(response, schema_data, schema_resolver):
-    """ Validates a response and raises a ResponseValidationError on failure.
-
-    :param response: the response object to validate
-    :type response: Pyramid response object passed into a view
-    :param schema_data: our mapping from request data to schemas (see
-        load_schema)
-    :type schema_data: dict
-    :param resolver: the request object to validate
-    :type resolver: Pyramid request object passed into a view
-    """
+def _validate_response(response, validator):
     try:
-        validate_outgoing_response(
-            response,
-            schema_data,
-            schema_resolver
-        )
+        validate_outgoing_response(response, validator)
     except jsonschema.exceptions.ValidationError as exc:
         # This will alter our stack trace slightly, but Pyramid knows how
         # to render it and the real value is in the message anyway.
@@ -278,7 +228,7 @@ def cast_request_param(request_schema, param_name, param_value):
         return param_value
 
 
-def validate_incoming_request(route_match, request, schema_map, resolver):
+def validate_incoming_request(route_match, request, validator_map):
     """Validates an incoming request against our schemas.
 
     :param route_match: a dict with all the path params and their values from
@@ -286,75 +236,40 @@ def validate_incoming_request(route_match, request, schema_map, resolver):
     :param route_match: dict
     :param request: the request object to validate
     :type request: Pyramid request object passed into a view
-    :param schema_map: our mapping from request data to schemas (see
-        load_schema)
-    :type schema_map: dict
-    :param resolver: the request object to validate
-    :type resolver: Pyramid request object passed into a view
-    :returns: None
+    :param validator_map: A :class:`pyramid_swagger.load_schema.ValidatorMap`
+        used to validate the request.
     """
-    for schema, values in [
-        (schema_map.request_query_schema, request.GET.items()),
-        (schema_map.request_path_schema, route_match),
-        (schema_map.request_header_schema, request.headers.items()),
+    for validator, values in [
+        (validator_map.query, request.GET.items()),
+        (validator_map.path, route_match),
+        (validator_map.headers, request.headers.items()),
     ]:
-        values = cast_params(schema, values)
-        validate_param_values(schema or {}, values, resolver)
+        validator.validate(cast_params(validator.schema, values))
 
-    # Body validation
-    if schema_map.request_body_schema:
-        body = getattr(request, 'json_body', {})
-        Draft4Validator(
-            schema_map.request_body_schema,
-            resolver=resolver,
-            types=EXTENDED_TYPES,
-        ).validate(body)
+    if not validator_map.body.schema:
+        return
+    validator_map.body.validate(getattr(request, 'json_body', {}))
 
 
 def cast_params(schema, values):
     if not schema:
-        return {}
+        return
     return dict((k, cast_request_param(schema, k, v)) for k, v in values)
 
 
-def validate_param_values(request_schema, values, resolver):
-    # You'll notice we use Draft3 some places and Draft4 in others.
-    # Unfortunately this is just Swagger's inconsistency showing. It
-    # may be nice in the future to do the necessary munging to make
-    # everything Draft4 compatible, although the Swagger UI will
-    # probably never truly support Draft5.
-    Draft3Validator(
-        request_schema,
-        resolver=resolver,
-        types=EXTENDED_TYPES,
-    ).validate(values)
-
-
-def validate_outgoing_response(response, schema_map, resolver):
+def validate_outgoing_response(response, validator):
     """Validates response against our schemas.
 
     :param response: the response object to validate
     :type response: Requests response object
-    :param schema_map: our mapping from request data to schemas (see
-        load_schema)
-    :type schema_map: dict
-    :param resolver: a resolver for validation, if any
-    :type resolver: a jsonschema resolver or None
-    :returns: None
     """
     # Short circuit if we are supposed to not validate anything.
     if (
-        schema_map.response_body_schema.get('type') == 'void' and
+        validator.schema.get('type') == 'void' and
         response.body in (None, b'', b'{}', b'null')
     ):
         return
-    body = prepare_body(response)
-
-    Draft4Validator(
-        schema_map.response_body_schema,
-        resolver=resolver,
-        types=EXTENDED_TYPES,
-    ).validate(body)
+    validator.validate(prepare_body(response))
 
 
 def prepare_body(response):

--- a/tests/acceptance/app/__init__.py
+++ b/tests/acceptance/app/__init__.py
@@ -3,11 +3,6 @@ from pyramid.config import Configurator
 from pyramid.view import view_config
 
 
-@view_config(route_name='sample_nonstring', renderer='json')
-def sample_nonstring(request):
-    return {}
-
-
 @view_config(route_name='standard', renderer='json')
 def standard(request, path_arg):
     return {
@@ -16,18 +11,12 @@ def standard(request, path_arg):
     }
 
 
+@view_config(route_name='sample_nonstring', renderer='json')
 @view_config(route_name='get_with_non_string_query_args', renderer='json')
-def get_with_non_string_query_args(request):
-    return {}
-
-
 @view_config(route_name='post_with_primitive_body', renderer='json')
-def post_with_primitive_body(request):
-    return {}
-
-
+@view_config(route_name='sample_header', renderer='json')
 @view_config(route_name='sample_post', renderer='json')
-def sample_post(request):
+def sample(request):
     return {}
 
 
@@ -48,6 +37,7 @@ def main(global_config, **settings):
     )
     config.add_route('post_with_primitive_body', '/post_with_primitive_body')
     config.add_route('sample_post', '/sample')
+    config.add_route('sample_header', '/sample/header')
 
     config.scan()
     return config.make_wsgi_app()

--- a/tests/acceptance/request_test.py
+++ b/tests/acceptance/request_test.py
@@ -152,6 +152,22 @@ def test_400_if_extra_query_args(test_app):
     ).status_code == 400
 
 
+def test_400_if_missing_required_header(test_app):
+    assert test_app.get(
+        '/sample/header',
+        expect_errors=True,
+    ).status_code == 400
+
+
+def test_200_with_required_header(test_app):
+    response = test_app.get(
+        '/sample/header',
+        headers={'X-Force': 'True'},
+        expect_errors=True,
+    )
+    assert response.status_code == 200
+
+
 def test_200_skip_validation_with_excluded_path():
     assert test_app(**{'pyramid_swagger.exclude_paths': [r'^/sample/?']}) \
         .get('/sample/test_request/resource') \

--- a/tests/ingest_test.py
+++ b/tests/ingest_test.py
@@ -40,7 +40,7 @@ def test_get_swagger_schema_default():
 
     swagger_schema = get_swagger_schema(settings)
     assert swagger_schema.resource_listing
-    assert swagger_schema.schema_resolvers
+    assert swagger_schema.resource_validators
 
 
 def test_get_swagger_schema_no_validation():

--- a/tests/model_test.py
+++ b/tests/model_test.py
@@ -21,41 +21,36 @@ def schema():
 
 
 def test_swagger_schema_for_request_different_methods(schema):
-    """Tests that schema_and_resolver_for_request() checks the request
+    """Tests that validators_for_request() checks the request
     method."""
     # There exists a GET and POST for this endpoint. We should be able to call
     # either and have them pass validation.
-    value, _ = schema.schema_and_resolver_for_request(
+    value = schema.validators_for_request(
         request=mock.Mock(
             path="/sample",
             method="GET"
         ),
     )
-    assert value.request_body_schema is None
+    assert value.body.schema is None
 
-    value, _ = schema.schema_and_resolver_for_request(
+    value = schema.validators_for_request(
         request=mock.Mock(
             path="/sample",
             method="POST",
             body={'foo': 1, 'bar': 2},
         ),
     )
-    assert (
-        value.request_body_schema == {
-            'required': True,
-            u'$ref': 'body_model'
-        }
-    )
+    assert value.body.schema == {'required': True, u'$ref': 'body_model'}
 
 
 def test_swagger_schema_for_request_not_found(schema):
-    """Tests that schema_and_resolver_for_request() raises exceptions when
+    """Tests that validators_for_request() raises exceptions when
     a path is not found.
     """
     # There exists a GET and POST for this endpoint. We should be able to call
     # either and have them pass validation.
     with pytest.raises(PathNotMatchedError) as excinfo:
-        schema.schema_and_resolver_for_request(
+        schema.validators_for_request(
             request=mock.Mock(
                 path="/does_not_exist",
                 method="GET"

--- a/tests/sample_schemas/good_app/other_sample.json
+++ b/tests/sample_schemas/good_app/other_sample.json
@@ -63,6 +63,24 @@
                     ]
                 }
             ]
+        },
+        {
+            "path": "/sample/header",
+            "operations": [
+                {
+                    "method": "GET",
+                    "nickname": "sample_header",
+                    "type": "void",
+                    "parameters": [
+                        {
+                            "paramType": "header",
+                            "name": "X-Force",
+                            "type": "boolean",
+                            "required": true
+                        }
+                    ]
+                }
+            ]
         }
     ],
     "models": {

--- a/tests/tween_test.py
+++ b/tests/tween_test.py
@@ -100,11 +100,13 @@ def test_validation_skips_path_properly():
 def test_validation_content_type_with_json():
     fake_schema = mock.Mock(response_body_schema={'type': 'object'})
     fake_validator = mock.Mock(schema=fake_schema)
+    body = {'status': 'good'}
     response = Response(
-        body=simplejson.dumps({'status': 'good'}),
+        body=simplejson.dumps(body),
         headers={'Content-Type': 'application/json; charset=UTF-8'},
     )
     validate_outgoing_response(response, fake_validator)
+    fake_validator.validate.assert_called_once_with(body)
 
 
 def test_raw_string():
@@ -115,3 +117,5 @@ def test_raw_string():
         headers={'Content-Type': 'application/text; charset=UTF-8'},
     )
     validate_outgoing_response(response, fake_validator)
+    fake_validator.validate.assert_called_once_with(
+        response.body.decode('utf-8'))

--- a/tests/tween_test.py
+++ b/tests/tween_test.py
@@ -99,17 +99,19 @@ def test_validation_skips_path_properly():
 # schemas easier there.
 def test_validation_content_type_with_json():
     fake_schema = mock.Mock(response_body_schema={'type': 'object'})
+    fake_validator = mock.Mock(schema=fake_schema)
     response = Response(
         body=simplejson.dumps({'status': 'good'}),
         headers={'Content-Type': 'application/json; charset=UTF-8'},
     )
-    validate_outgoing_response(response, fake_schema, None)
+    validate_outgoing_response(response, fake_validator)
 
 
 def test_raw_string():
     fake_schema = mock.Mock(response_body_schema={'type': 'string'})
+    fake_validator = mock.Mock(schema=fake_schema)
     response = Response(
         body='abe1351f',
         headers={'Content-Type': 'application/text; charset=UTF-8'},
     )
-    validate_outgoing_response(response, fake_schema, None)
+    validate_outgoing_response(response, fake_validator)


### PR DESCRIPTION
Resolves #1 - header validation

As I was working on #22 I noticed that I was having to frequently pass around a `resolver`, but that resolver was only ever going to be used with the `schema` that came from the same place.

This refactor exposes a `SchemaValidator` object instead of the the `SchemaAndResolver` object. The validator can be used directly to validate a field from the request or response, but it also stores the original schema which can be used to cast values.

Exposing a validator instead of the schema and resolver should allow us to make changes to the validator (as suggested by some TODOs added in this PR) in a single location (`load_schema`). Previously it would require changes to both `load_schema` and `tween`. 

I think it also makes the tween easier to reason about.  All of the validation logic is now part of the model/load_schema.  The tween only needs to iterate over the fields and validate each without worrying about the implementation of that validation.