### PR TITLE
Allow for empty body without headers for void responses

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,10 @@ Changelog
   routes which will be ignored for validation purposes.
 * Added ``generate_resource_listing`` configuration option to allow
   pyramid_swagger to generate the ``apis`` section of the resource listing.
+* Bug fix for issues relating to ``void`` responses (See `Issue 79`_)
+
+.. _Issue 79: https://github.com/striglia/pyramid_swagger/issues/79
+
 
 1.4.0 (2015-01-27)
 ++++++++++++++++++

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -93,7 +93,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  Major themes that come with
 # Sphinx are currently 'default' and 'sphinxdoc'.
-html_theme = 'default'
+html_theme = 'classic'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/external_resources.rst
+++ b/docs/external_resources.rst
@@ -5,5 +5,5 @@ There are a variety of external resources you will find useful when documenting
 your API with Swagger.
 
 * `Interactive Spec Editor <http://editor.swagger.io/>`_
-* `Swagger 1.2 Specification <https://github.com/wordnik/swagger-spec/blob/master/versions/1.2.md>`_
-* `"Pet Store" example API <http://petstore.swagger.wordnik.com/>`_
+* `Swagger 1.2 Specification <https://github.com/swagger-api/swagger-spec/blob/master/versions/1.2.md>`_
+* `"Pet Store" example API <http://petstore.swagger.io/>`_

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -13,4 +13,4 @@ api declaration
   The description of each endpoint a particular Swagger service provides, with complete input and output declared.
 
 swagger spec
-  The formal specification of a valid swagger api. The current public version is 1.2 and hosted on `wordnik's Github <https://github.com/wordnik/swagger-spec/blob/master/versions/1.2.md>`_.
+  The formal specification of a valid swagger api. The current public version is 1.2 and hosted on `wordnik's Github <https://github.com/swagger-api/swagger-spec/blob/master/versions/1.2.md>`_.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,7 +15,7 @@ Features include:
 
 * Swagger spec validation
 
-* Automatically serving the swagger schema to interested clients (e.g. `Swagger UI <https://github.com/wordnik/swagger-ui>`_)
+* Automatically serving the swagger schema to interested clients (e.g. `Swagger UI <https://github.com/swagger-api/swagger-ui>`_)
 
 
 Contents:

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -1,5 +1,5 @@
 Quickstart
-===========================================
+==========
 
 So let's get your pyramid app up and running!
 
@@ -13,7 +13,7 @@ Creating your first API declaration
 
 Creating your initial API declaration can be intimidating but don't fear, it's not nearly as much work as it might initially appear.
 
-To create your first API declaration, I encourage you to take a look at Swagger's official `PetStore example <http://petstore.swagger.wordnik.com>`_. You can even see the raw JSON for the associated API declarations, like the `Pet resource. <http://petstore.swagger.wordnik.com/api/api-docs/pet>`_ You'll notice that Swagger has a lot of details, but the core part of building a schema is documenting each endpoint's inputs and outputs.
+To create your first API declaration, I encourage you to take a look at Swagger's official `PetStore example <http://petstore.swagger.io>`_. You can even see the raw JSON for the associated API declarations, like the `Pet resource. <http://petstore.swagger.io/api/api-docs/pet>`_ You'll notice that Swagger has a lot of details, but the core part of building a schema is documenting each endpoint's inputs and outputs.
 
 For your intial attempt, documenting an endpoint can be simplified to some basic components:
 
@@ -23,12 +23,12 @@ For your intial attempt, documenting an endpoint can be simplified to some basic
 
 There are many other pieces of your REST interface that Swagger can describe, but these are the core components. The PetStore example has some good examples of all of these various types, so it can be a useful reference as you get used to the syntax.
 
-For any questions about various details of documenting your interface with Swagger, you can consult the official `Swagger Spec <https://github.com/wordnik/swagger-spec/blob/master/versions/1.2.md>`_, although you may find it somewhat difficult to parse for use as anything but a reference.
+For any questions about various details of documenting your interface with Swagger, you can consult the official `Swagger Spec <https://github.com/swagger-api/swagger-spec/blob/master/versions/1.2.md>`_, although you may find it somewhat difficult to parse for use as anything but a reference.
 
 You may find that the process of writing your API down in the Swagger format is surprisingly hard...this is good! It probably suggests that your API is not terribly well understood or maybe even underspecified right now. Anecdotally, users commonly report that writing their first Swagger api-docs has the unintended side effect of forcing them to reconsider exactly how their service should be interacting with the outside world -- a useful exercise!
 
 Where to put your API declaration
------------------------------------
+---------------------------------
 
 Great, so we have one large JSON file containing our API declaration for all endpoints our service supports. What now?
 
@@ -51,7 +51,7 @@ Now place the API declaration you wrote previously in :samp:`api_docs/sample.jso
 Going forward, you'll want to use these resources to separate out the logical pieces of your service's interface. You are encouraged to split your single API declaration into a few cohesive resources that make sense for your particular API!
 
 Add pyramid_swagger to your webapp
------------------------------------
+----------------------------------
 
 Last but not least, we need to turn on the pyramid_swagger library within your application. This is quite easy by default, either by augmenting your PasteDeploy .ini file, or by adding a line to your webapp method.
 

--- a/pyramid_swagger/tween.py
+++ b/pyramid_swagger/tween.py
@@ -343,10 +343,14 @@ def validate_outgoing_response(response, schema_map, resolver):
     :type resolver: a jsonschema resolver or None
     :returns: None
     """
-    body = prepare_body(response)
     # Short circuit if we are supposed to not validate anything.
-    if schema_map.response_body_schema.get('type') == 'void' and body is None:
+    if (
+        schema_map.response_body_schema.get('type') == 'void' and
+        response.body in (None, b'', b'{}', b'null')
+    ):
         return
+    body = prepare_body(response)
+
     Draft4Validator(
         schema_map.response_body_schema,
         resolver=resolver,

--- a/tests/acceptance/response_test.py
+++ b/tests/acceptance/response_test.py
@@ -106,7 +106,7 @@ def test_500_when_response_is_missing_required_field():
         _validate_against_tween(request, response=response)
 
 
-def test_200_when_response_is_void():
+def test_200_when_response_is_void_with_none_response():
     request = pyramid.testing.DummyRequest(
         method='GET',
         path='/sample/nonstring/{int_arg}/{float_arg}/{boolean_arg}',
@@ -117,6 +117,17 @@ def test_200_when_response_is_void():
         body=simplejson.dumps(None),
         headers={'Content-Type': 'application/json; charset=UTF-8'},
     )
+    _validate_against_tween(request, response=response)
+
+
+def test_200_when_response_is_void_with_empty_response():
+    request = pyramid.testing.DummyRequest(
+        method='GET',
+        path='/sample/nonstring/{int_arg}/{float_arg}/{boolean_arg}',
+        params={'required_arg': 'test'},
+        matchdict={'int_arg': '1', 'float_arg': '2.0', 'boolean_arg': 'true'},
+    )
+    response = Response(body='{}')
     _validate_against_tween(request, response=response)
 
 


### PR DESCRIPTION
Resolves #79 

Addresses two issues:
* a `Context-Type` was expected even for void responses
* a response of an empty dict would fail validation (because it wasn't None)