### PR TITLE
Add support for validating form-encoded bodies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ build/
 dist/
 .coverage
 .tox
+.ropeproject
 pyramid_swagger.egg-info
 tests/__pycache__

--- a/pyramid_swagger/load_schema.py
+++ b/pyramid_swagger/load_schema.py
@@ -127,7 +127,9 @@ Swagger12ParamValidator = validators.extend(
 )
 
 
-class ValidatorMap(namedtuple('_VMap', 'query path headers body response')):
+class ValidatorMap(
+    namedtuple('_VMap', 'query path form headers body response')
+):
     """
     A data object with validators for each part of the request and response
     objects. Each field is a :class:`SchemaValidator`.
@@ -140,6 +142,7 @@ class ValidatorMap(namedtuple('_VMap', 'query path headers body response')):
         for schema, validator in [
             (build_param_schema(operation, 'query'), Swagger12ParamValidator),
             (build_param_schema(operation, 'path'), Swagger12ParamValidator),
+            (build_param_schema(operation, 'form'), Swagger12ParamValidator),
             (build_param_schema(operation, 'header'), Swagger12ParamValidator),
             (extract_body_schema(operation), get_body_validator(models)),
             (extract_response_body_schema(operation, models),

--- a/pyramid_swagger/tween.py
+++ b/pyramid_swagger/tween.py
@@ -134,6 +134,11 @@ class PyramidSwaggerRequest(object):
     data for casting and validation.
     """
 
+    FORM_TYPES = [
+        'application/x-www-form-urlencoded',
+        'multipart/form-data',
+    ]
+
     def __init__(self, request, route_info):
         self.request = request
         self.route_info = route_info
@@ -149,6 +154,13 @@ class PyramidSwaggerRequest(object):
     @property
     def headers(self):
         return self.request.headers
+
+    @property
+    def form(self):
+        # Don't read the POST dict unless the body is form encoded
+        if self.request.headers.get('Content-Type') in self.FORM_TYPES:
+            return self.request.POST
+        return {}
 
     @property
     def body(self):
@@ -174,6 +186,7 @@ def handle_request(request, validation_context, validator_map):
     for validator, values in [
         (validator_map.query, request.query),
         (validator_map.path, request.path),
+        (validator_map.form, request.form),
         (validator_map.headers, request.headers),
     ]:
         values = cast_params(validator.schema, values)

--- a/tests/acceptance/app/__init__.py
+++ b/tests/acceptance/app/__init__.py
@@ -16,6 +16,7 @@ def standard(request, path_arg):
 @view_config(route_name='post_with_primitive_body', renderer='json')
 @view_config(route_name='sample_header', renderer='json')
 @view_config(route_name='sample_post', renderer='json')
+@view_config(route_name='post_with_form_params', renderer='json')
 def sample(request):
     if not request.registry.settings.get('skip_swagger_data_assert'):
         assert request.swagger_data
@@ -38,6 +39,7 @@ def main(global_config, **settings):
         '/get_with_non_string_query_args',
     )
     config.add_route('post_with_primitive_body', '/post_with_primitive_body')
+    config.add_route('post_with_form_params', '/post_with_form_params')
     config.add_route('sample_post', '/sample')
     config.add_route('sample_header', '/sample/header')
 

--- a/tests/acceptance/request_test.py
+++ b/tests/acceptance/request_test.py
@@ -30,6 +30,29 @@ def validation_context(request, response=None):
 validation_ctx_path = 'tests.acceptance.request_test.validation_context'
 
 
+def test_200_with_form_params(test_app):
+    assert test_app.post(
+        '/post_with_form_params',
+        {'form_param': 42},
+    ).status_code == 200
+
+
+def test_400_with_form_params_wrong_type(test_app):
+    assert test_app.post(
+        '/post_with_form_params',
+        {'form_param': "not a number"},
+        expect_errors=True,
+    ).status_code == 400
+
+
+def test_400_if_json_body_for_form_parms(test_app):
+    assert test_app.post_json(
+        '/post_with_form_params',
+        {'form_param': 42},
+        expect_errors=True,
+    ).status_code == 400
+
+
 def test_400_if_required_query_args_absent(test_app):
     assert test_app.get(
         '/sample/path_arg1/resource',
@@ -105,6 +128,7 @@ def test_200_on_json_body_without_contenttype_header(test_app):
     assert test_app.post(
         '/sample?optional_string=bar',
         simplejson.dumps({'foo': 'test'}),
+        {'Content-Type': ''},
     ).status_code == 200
 
 

--- a/tests/sample_schemas/good_app/sample.json
+++ b/tests/sample_schemas/good_app/sample.json
@@ -67,6 +67,24 @@
             ]
         },
         {
+            "path": "/post_with_form_params",
+            "operations": [
+                {
+                    "method": "POST",
+                    "nickname": "post_with_form_params",
+                    "type": "object",
+                    "parameters": [
+                        {
+                            "name": "form_param",
+                            "type": "integer",
+                            "paramType": "form",
+                            "required": true
+                        }
+                    ]
+                }
+            ]
+        },
+        {
             "path": "/get_with_non_string_query_args",
             "operations": [
                 {

--- a/tests/tween_test.py
+++ b/tests/tween_test.py
@@ -140,6 +140,7 @@ def test_handle_request_returns_request_data():
     mock_request = mock.Mock(
         spec=PyramidSwaggerRequest,
         query={'int': '123', 'float': '3.14'},
+        form={'form_int': '333', 'string2': 'xyz'},
         path={'path_int': '222', 'string': 'abc'},
         headers={'X-Is-Bool': 'True'},
         body={'more': 'foo'},
@@ -151,6 +152,7 @@ def test_handle_request_returns_request_data():
     validator_map = mock.Mock(
         query=build_mock_validator({'int': 'integer', 'float': 'float'}),
         path=build_mock_validator({'path_int': 'integer', 'string': 'string'}),
+        form=build_mock_validator({'form_int': 'integer'}),
         headers=build_mock_validator({'X-Is-Bool': 'boolean'}),
         body=body_validator,
     )
@@ -159,7 +161,9 @@ def test_handle_request_returns_request_data():
         'int': 123,
         'float': 3.14,
         'path_int': 222,
+        'form_int': 333,
         'string': 'abc',
+        'string2': 'xyz',
         'X-Is-Bool': True,
         'bar': {'more': 'foo'},
     }


### PR DESCRIPTION
Adds support for validating arguments of `"paramType": "form"`. Fixes #53. 

Looking for some feedback to make sure I'm doing it right and not missing anything.