### PR TITLE
Refactor api_doc registering to support 2.0

### DIFF
--- a/pyramid_swagger/__init__.py
+++ b/pyramid_swagger/__init__.py
@@ -20,4 +20,8 @@ def includeme(config):
     )
 
     if settings.get('pyramid_swagger.enable_api_doc_views', True):
-        register_api_doc_endpoints(config)
+        # TODO: add a new setting to pyramid_swagger that allows setting a
+        # different base_path for api_docs, and pass it in here
+        register_api_doc_endpoints(
+            config,
+            settings['pyramid_swagger.schema'].get_api_doc_endpoints())

--- a/pyramid_swagger/ingest.py
+++ b/pyramid_swagger/ingest.py
@@ -5,6 +5,7 @@ import glob
 import os.path
 import simplejson
 
+from .api import build_swagger_12_endpoints
 from .load_schema import load_schema
 from .model import SwaggerSchema
 from .spec import validate_swagger_schemas
@@ -122,7 +123,8 @@ def compile_swagger_schema(schema_dir, resource_listing):
     """
     mapping = build_schema_mapping(schema_dir, resource_listing)
     resource_validators = ingest_resources(mapping, schema_dir)
-    return SwaggerSchema(resource_listing, mapping, resource_validators)
+    endpoints = list(build_swagger_12_endpoints(resource_listing, mapping))
+    return SwaggerSchema(endpoints, resource_validators)
 
 
 def validate_swagger_schema(schema_dir, resource_listing):

--- a/pyramid_swagger/model.py
+++ b/pyramid_swagger/model.py
@@ -3,7 +3,13 @@
 The core model we use to represent the entire ingested swagger schema for this
 service.
 """
+from collections import namedtuple
 import re
+
+
+PyramidEndpoint = namedtuple(
+    'PyramidEndpoint',
+    'path route_name view renderer')
 
 
 class PathNotMatchedError(Exception):
@@ -18,24 +24,16 @@ class SwaggerSchema(object):
     and exposes methods for efficiently finding the relevant schemas for a
     Pyramid request.
 
-    :param resource_listing: A swagger resource listing
-    :type resource_listing: dict
-    :param api_declarations: Map from resource name to filepath of its api
-        declaration
-    :type api_declarations: dict
+    :param pyramid_endpoints: a list of :class:`PyramidEndpoint` which define
+        the pyramid endpoints to create for serving the api docs
     :param resource_validators: a list of resolvers, one per Swagger resource
     :type resource_validators: list of mappings from :class:`RequestMatcher`
         to :class:`ValidatorMap`
     for every operation in the api specification.
     """
 
-    def __init__(
-            self,
-            resource_listing,
-            api_declarations,
-            resource_validators):
-        self.resource_listing = resource_listing
-        self.api_declarations = api_declarations
+    def __init__(self, pyramid_endpoints, resource_validators):
+        self.pyramid_endpoints = pyramid_endpoints
         self.resource_validators = resource_validators
 
     def validators_for_request(self, request):
@@ -55,6 +53,9 @@ class SwaggerSchema(object):
             'Could not find the relevant path ({0}) in the Swagger schema. '
             'Perhaps you forgot to add it?'.format(request.path)
         )
+
+    def get_api_doc_endpoints(self):
+        return self.pyramid_endpoints
 
 
 def partial_path_match(path1, path2, kwarg_re=r'\{.*\}'):

--- a/tests/ingest_test.py
+++ b/tests/ingest_test.py
@@ -39,7 +39,7 @@ def test_get_swagger_schema_default():
     }
 
     swagger_schema = get_swagger_schema(settings)
-    assert swagger_schema.resource_listing
+    assert len(swagger_schema.pyramid_endpoints) == 4
     assert swagger_schema.resource_validators
 
 


### PR DESCRIPTION
This addresses task 4 in #94 

It starts to add support for a things:
* it will allow multiple sets of api_docs to be registered by calling `pyramid_swagger.api.register_api_doc_endpoints`. This will be necessary for our transition to swagger 2.0. The plan is currently to serve api docs for both swagger 1.2 and 2.0, but only validate against the 2.0 specs.  This way both sets of clients will continue to work.
* allows for the base_path of the api docs to be customized, this is kind of necessary if we're registering multiple sets of docs
* provides a method on the `SwaggerSchema` interface that can be used to abstract away the difference between swagger 1.2 and 2.0 api docs. This will allow us to keep all the version switches in a single module (`pyramid_swagger.ingest`).

I've left the documentation and settings changes as TODOs for now so we can discuss this further and make sure this is the right approach.