### PR TITLE
Rc2

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,9 +1,14 @@
 Changelog
 =========
 
-1.5.0-dev (2015-02-25)
+1.5.0-rc2 (2015-03-31)
 ++++++++++++++++++++++
 **Under development**
+
+* Form-encoded bodies are now validated correctly.
+
+1.5.0-rc1 (2015-03-30)
+++++++++++++++++++++++
 
 * Added ``enable_api_docs_views`` configuration option so /api-docs
   auto-registration can be disabled in situations where users want to serve

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -177,6 +177,15 @@ latex_documents = [
   ('index', 'pyramid_swagger.tex', u'pyramid\\_swagger Documentation',
    u'Scott Triglia', 'manual'),
 ]
+latex_elements = {
+    # Additional stuff for the LaTeX preamble. See
+    # https://github.com/rtfd/readthedocs.org/issues/416
+    'preamble': "".join((
+        '\DeclareUnicodeCharacter{00A0}{ }',  # NO-BREAK SPACE
+        '\DeclareUnicodeCharacter{251C}{+}',  # BOX DRAWINGS LIGHT VERTICAL AND RIGHT
+        '\DeclareUnicodeCharacter{2514}{+}',  # BOX DRAWINGS LIGHT UP AND RIGHT
+    )),
+}
 
 # The name of an image file (relative to this directory) to place at the top of
 # the title page.

--- a/pyramid_swagger/__about__.py
+++ b/pyramid_swagger/__about__.py
@@ -13,7 +13,7 @@ __title__ = "pyramid_swagger"
 __summary__ = "Swagger tools for use in pyramid webapps"
 __uri__ = "https://github.com/striglia/pyramid_swagger"
 
-__version__ = "1.5.0-rc1"
+__version__ = "1.5.0-rc2"
 
 __author__ = "Scott Triglia"
 __email__ = "scott.triglia@gmail.com"


### PR DESCRIPTION
Bumps our setup.py version to rc2. Adds form-encoded line in changelog. Patches ReadTheDocs latex bug to resolve #92.