### PR TITLE
Service both Swagger 1.2 and 2.0 clients 

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -17,7 +17,10 @@ A few relevant settings for your `Pyramid .ini file <http://docs.pylonsproject.o
         # Default: 'api_docs/'
         pyramid_swagger.schema_directory = "schemas/live/here"
 
-        # Versions of Swagger to support.
+        # Versions of Swagger to support. When both Swagger 1.2 and 2.0 are
+        # supported, it is required for both schemas to define identical APIs.
+        # In this dual-support mode, requests are validated against the Swagger
+        # 2.0 schema only.
         # Default: ['2.0']
         # Supported versions: '1.2', '2.0'
         pyramid_swagger.swagger_versions = ['2.0']

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -12,9 +12,15 @@ A few relevant settings for your `Pyramid .ini file <http://docs.pylonsproject.o
         # Add the pyramid_swagger validation tween to your app (required)
         pyramid.includes = pyramid_swagger
 
-        # `api_docs.json` directory location.
+        # `api_docs.json` for Swagger 1.2 and/or `swagger.json` for Swagger 2.0
+        # directory location.
         # Default: 'api_docs/'
         pyramid_swagger.schema_directory = "schemas/live/here"
+
+        # Versions of Swagger to support.
+        # Default: ['2.0']
+        # Supported versions: '1.2', '2.0'
+        pyramid_swagger.swagger_versions = ['2.0']
 
         # Check the correctness of Swagger spec files.
         # Default: True
@@ -36,8 +42,8 @@ A few relevant settings for your `Pyramid .ini file <http://docs.pylonsproject.o
 
         # Exclude certain endpoints from validation. Takes a list of regular
         # expressions.
-        # Default: [r'^/static/?', r'^/api-docs/?']
-        pyramid_swagger.exclude_paths = [r'^/static/?', r'^/api-docs/?']
+        # Default: [r'^/static/?', r'^/api-docs/?, r'^/swagger.json']
+        pyramid_swagger.exclude_paths = [r'^/static/?', r'^/api-docs/?', r'^/swagger.json']
 
         # Exclude pyramid routes from validation. Accepts a list of strings
         pyramid_swagger.exclude_routes = ['catchall', 'no-validation']
@@ -70,8 +76,8 @@ Note that, equivalently, you can add these during webapp configuration:
             config.include('pyramid_swagger')
 
 
-generate_resource_listing
--------------------------
+generate_resource_listing (Swagger 1.2 only)
+--------------------------------------------
 
 With a large API (many Resource objects) the boilerplate ``apis`` field of
 the `Resource Listing`_ document can become painful to maintain. This

--- a/docs/external_resources.rst
+++ b/docs/external_resources.rst
@@ -6,4 +6,5 @@ your API with Swagger.
 
 * `Interactive Spec Editor <http://editor.swagger.io/>`_
 * `Swagger 1.2 Specification <https://github.com/swagger-api/swagger-spec/blob/master/versions/1.2.md>`_
+* `Swagger 2.0 Specification <https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md>`_
 * `"Pet Store" example API <http://petstore.swagger.io/>`_

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -13,4 +13,4 @@ api declaration
   The description of each endpoint a particular Swagger service provides, with complete input and output declared.
 
 swagger spec
-  The formal specification of a valid swagger api. The current public version is 1.2 and hosted on `wordnik's Github <https://github.com/swagger-api/swagger-spec/blob/master/versions/1.2.md>`_.
+  The formal specification of a valid swagger api. The current public version is 2.0 and hosted on `wordnik's Github <https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md>`_.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,6 +11,8 @@ your interfaces in a `Pyramid <http://www.pylonsproject.org/>`_ webapp.
 
 Features include:
 
+* Support for Swagger 1.2 and Swagger 2.0
+
 * Request and response validation
 
 * Swagger spec validation

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -5,15 +5,15 @@ So let's get your pyramid app up and running!
 
 The core steps to use pyramid_swagger are quite simple:
 
-1. Create a Swagger API declaration for your service's endpoints
+1. Create a Swagger Schema for your service's endpoints
 2. Add pyramid_swagger to your Pyramid application
 
-Creating your first API declaration
+Creating your first Swagger Schema
 -----------------------------------
 
-Creating your initial API declaration can be intimidating but don't fear, it's not nearly as much work as it might initially appear.
+Creating your initial Swagger Schema can be intimidating but don't fear, it's not nearly as much work as it might initially appear.
 
-To create your first API declaration, I encourage you to take a look at Swagger's official `PetStore example <http://petstore.swagger.io>`_. You can even see the raw JSON for the associated API declarations, like the `Pet resource. <http://petstore.swagger.io/api/api-docs/pet>`_ You'll notice that Swagger has a lot of details, but the core part of building a schema is documenting each endpoint's inputs and outputs.
+To create your first Swagger Schema, I encourage you to take a look at Swagger's official `PetStore example <http://petstore.swagger.io>`_. You can even see the raw JSON for the `Swagger Schema. <http://petstore.swagger.io/v2/swagger.json>`_ You'll notice that Swagger has a lot of details, but the core part of building a schema is documenting each endpoint's inputs and outputs.
 
 For your intial attempt, documenting an endpoint can be simplified to some basic components:
 
@@ -23,32 +23,16 @@ For your intial attempt, documenting an endpoint can be simplified to some basic
 
 There are many other pieces of your REST interface that Swagger can describe, but these are the core components. The PetStore example has some good examples of all of these various types, so it can be a useful reference as you get used to the syntax.
 
-For any questions about various details of documenting your interface with Swagger, you can consult the official `Swagger Spec <https://github.com/swagger-api/swagger-spec/blob/master/versions/1.2.md>`_, although you may find it somewhat difficult to parse for use as anything but a reference.
+For any questions about various details of documenting your interface with Swagger, you can consult the official `Swagger Spec <https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md>`_, although you may find it somewhat difficult to parse for use as anything but a reference.
 
 You may find that the process of writing your API down in the Swagger format is surprisingly hard...this is good! It probably suggests that your API is not terribly well understood or maybe even underspecified right now. Anecdotally, users commonly report that writing their first Swagger api-docs has the unintended side effect of forcing them to reconsider exactly how their service should be interacting with the outside world -- a useful exercise!
 
-Where to put your API declaration
+Where to put your Swagger Schema
 ---------------------------------
 
 Great, so we have one large JSON file containing our API declaration for all endpoints our service supports. What now?
 
-Well you need one other ingredient -- a resource listing. These break up your service into logical resources. To get started, let's just create an extremely simple one. Write the following into :samp:`api_docs/api_docs.json`.
-
-.. code-block:: json
-
-        {
-          "swaggerVersion": "1.2",
-          "apis": [
-            {
-              "path": "/sample",
-              "description": "Sample valid api declaration."
-            }
-          ]
-        }
-
-Now place the API declaration you wrote previously in :samp:`api_docs/sample.json`. You'll notice that our path is named the same as our API declaration file -- this is not by accident! The path has no relation to the paths described in your API declaration, it is only used internally to help Swagger discover your schemas.
-
-Going forward, you'll want to use these resources to separate out the logical pieces of your service's interface. You are encouraged to split your single API declaration into a few cohesive resources that make sense for your particular API!
+Now place the Swagger Schema in :samp:`api_docs/swagger.json`. The path has no relation to the paths described in your API declaration, it is only used internally to help Swagger discover your schemas.
 
 Add pyramid_swagger to your webapp
 ----------------------------------
@@ -66,17 +50,17 @@ With that, when your app starts you will get the benefit of:
 
 * 4xx errors for requests not matching your schema
 * 5xx errors for responses not matching your schema
-* Automatic validation for correctness of your API declaration at application startup
-* Automatic serving of your Swagger schema from the /api-docs endpoint
+* Automatic validation for correctness of your Swagger Schema at application startup
+* Automatic serving of your Swagger Schema from the /swagger.json endpoint
 
 
 Accessing request data
 ----------------------
 
 Now that :mod:`pyramid_swagger` is enabled you can create a view. All the
-values that are specified in the swagger spec for an endpoint are available
+values that are specified in the Swagger Schema for an endpoint are available
 from a single :class:`dict` on the request  ``request.swagger_data``. These
-values are casted to the type specified by the swagger spec.
+values are casted to the type specified by the Swagger Schema.
 
 Example:
 

--- a/pyramid_swagger/__init__.py
+++ b/pyramid_swagger/__init__.py
@@ -4,11 +4,35 @@ Import this module to add the validation tween to your pyramid app.
 """
 import pyramid
 
-from .api import register_api_doc_endpoints
-from .api import register_swagger_json_endpoint
+from .api import register_api_doc_endpoints, build_swagger_20_swagger_dot_json
 from .ingest import get_swagger_schema
 from .ingest import get_swagger_spec
-from .model import PyramidEndpoint
+
+SWAGGER_12 = '1.2'
+SWAGGER_20 = '2.0'
+DEFAULT_SWAGGER_VERSIONS = [SWAGGER_20]
+SUPPORTED_SWAGGER_VERSIONS = [SWAGGER_12, SWAGGER_20]
+
+
+def get_swagger_versions(settings):
+    """
+    Validates and returns the versions of the Swagger Spec that this pyramid
+    application supports.
+
+    :type settings: dict
+    :return: list of strings. eg ['1.2', '2.0']
+    """
+    swagger_versions = settings.get(
+        'pyramid_swagger.swagger_versions', DEFAULT_SWAGGER_VERSIONS)
+
+    if len(swagger_versions) == 0:
+        raise ValueError('pyramid_swagger.swagger_versions is empty')
+
+    for swagger_version in swagger_versions:
+        if swagger_version not in SUPPORTED_SWAGGER_VERSIONS:
+            raise ValueError('Swagger version {0} is not supported.'
+                             .format(swagger_version))
+    return swagger_versions
 
 
 def includeme(config):
@@ -19,15 +43,14 @@ def includeme(config):
 
     # Add the SwaggerSchema to settings to make it avialable to the validation
     # tween and `register_api_doc_endpoints`
-    swagger_version = settings.get('pyramid_swagger.swagger_version', '2.0')
+    swagger_versions = get_swagger_versions(settings)
 
-    if swagger_version == '1.2':
-        settings['pyramid_swagger.schema'] = get_swagger_schema(settings)
-    elif swagger_version == '2.0':
+    if SWAGGER_12 in swagger_versions:
+        settings['pyramid_swagger.schema'] = \
+            settings['pyramid_swagger.schema12'] = get_swagger_schema(settings)
+
+    if SWAGGER_20 in swagger_versions:
         settings['pyramid_swagger.schema'] = get_swagger_spec(settings)
-    else:
-        raise TypeError('Unsupported pyramid_swagger.swagger_version: {0}'
-                        .format(swagger_version))
 
     config.add_tween(
         "pyramid_swagger.tween.validation_tween_factory",
@@ -35,28 +58,26 @@ def includeme(config):
     )
 
     if settings.get('pyramid_swagger.enable_api_doc_views', True):
-        if swagger_version == '1.2':
-            # TODO: add a new setting to pyramid_swagger that allows setting a
-            #       different base_path for api_docs, and pass it in here
-            register_api_doc_endpoints(
-                config,
-                settings['pyramid_swagger.schema'].get_api_doc_endpoints())
+        endpoints = []
+        if SWAGGER_12 in swagger_versions:
+            endpoints += \
+                settings['pyramid_swagger.schema12'].get_api_doc_endpoints()
 
-        if swagger_version == '2.0':
+        if SWAGGER_20 in swagger_versions:
+            endpoints.append(build_swagger_20_swagger_dot_json(config))
 
-            def view_for_swagger_json(request):
-                spec = config.registry.settings['pyramid_swagger.schema']
-                return spec.spec_dict
+        # TODO: There are competing concerns here - for Swagger 1.2 the schemas
+        #       are usually served up under /api-docs for the resource listing
+        #       and /api-docs/{resource_name} for the api declarations. For
+        #       Swagger 2.0 the default behavior should be to serve up the
+        #       schema as /swagger.json. Since register_api_doc_endpoints(..)
+        #       uses the same base_path regardless of the endpoint, both use
+        #       cases can't be satisfied unless the base_path is coupled with
+        #       a given PyramidEndpoint. I've worked around this by changing
+        #       the path of the 1.2 endpoints to include /api-docs in the
+        #       'path' so that an empty base_path can be passed in to this
+        #       function call and behave as expected.
 
-            swagger_json_endpoint = PyramidEndpoint(
-                path='/swagger.json',
-                route_name='pyramid_swagger.swagger20.api_docs',
-                view=view_for_swagger_json,
-                renderer='json')
-
-            # TODO: add a new setting to pyramid_swagger that allows setting a
-            #       different base_path for api_docs, and pass it in here
-            register_api_doc_endpoints(
-                config,
-                [swagger_json_endpoint],
-                base_path='')
+        # TODO: add a new setting to pyramid_swagger that allows setting a
+        #       different base_path for api_docs, and pass it in here
+        register_api_doc_endpoints(config, endpoints, base_path='')

--- a/pyramid_swagger/__init__.py
+++ b/pyramid_swagger/__init__.py
@@ -7,32 +7,7 @@ import pyramid
 from .api import register_api_doc_endpoints, build_swagger_20_swagger_dot_json
 from .ingest import get_swagger_schema
 from .ingest import get_swagger_spec
-
-SWAGGER_12 = '1.2'
-SWAGGER_20 = '2.0'
-DEFAULT_SWAGGER_VERSIONS = [SWAGGER_20]
-SUPPORTED_SWAGGER_VERSIONS = [SWAGGER_12, SWAGGER_20]
-
-
-def get_swagger_versions(settings):
-    """
-    Validates and returns the versions of the Swagger Spec that this pyramid
-    application supports.
-
-    :type settings: dict
-    :return: list of strings. eg ['1.2', '2.0']
-    """
-    swagger_versions = settings.get(
-        'pyramid_swagger.swagger_versions', DEFAULT_SWAGGER_VERSIONS)
-
-    if len(swagger_versions) == 0:
-        raise ValueError('pyramid_swagger.swagger_versions is empty')
-
-    for swagger_version in swagger_versions:
-        if swagger_version not in SUPPORTED_SWAGGER_VERSIONS:
-            raise ValueError('Swagger version {0} is not supported.'
-                             .format(swagger_version))
-    return swagger_versions
+from .tween import get_swagger_versions, SWAGGER_12, SWAGGER_20
 
 
 def includeme(config):
@@ -40,12 +15,12 @@ def includeme(config):
     :type config: :class:`pyramid.config.Configurator`
     """
     settings = config.registry.settings
-
-    # Add the SwaggerSchema to settings to make it avialable to the validation
-    # tween and `register_api_doc_endpoints`
     swagger_versions = get_swagger_versions(settings)
 
+    # Add the SwaggerSchema to settings to make it available to the validation
+    # tween and `register_api_doc_endpoints`
     if SWAGGER_12 in swagger_versions:
+        # Store under two keys so that 1.2 and 2.0 can co-exist.
         settings['pyramid_swagger.schema'] = \
             settings['pyramid_swagger.schema12'] = get_swagger_schema(settings)
 
@@ -58,26 +33,15 @@ def includeme(config):
     )
 
     if settings.get('pyramid_swagger.enable_api_doc_views', True):
-        endpoints = []
-        if SWAGGER_12 in swagger_versions:
-            endpoints += \
-                settings['pyramid_swagger.schema12'].get_api_doc_endpoints()
-
-        if SWAGGER_20 in swagger_versions:
-            endpoints.append(build_swagger_20_swagger_dot_json(config))
-
-        # TODO: There are competing concerns here - for Swagger 1.2 the schemas
-        #       are usually served up under /api-docs for the resource listing
-        #       and /api-docs/{resource_name} for the api declarations. For
-        #       Swagger 2.0 the default behavior should be to serve up the
-        #       schema as /swagger.json. Since register_api_doc_endpoints(..)
-        #       uses the same base_path regardless of the endpoint, both use
-        #       cases can't be satisfied unless the base_path is coupled with
-        #       a given PyramidEndpoint. I've worked around this by changing
-        #       the path of the 1.2 endpoints to include /api-docs in the
-        #       'path' so that an empty base_path can be passed in to this
-        #       function call and behave as expected.
-
         # TODO: add a new setting to pyramid_swagger that allows setting a
         #       different base_path for api_docs, and pass it in here
-        register_api_doc_endpoints(config, endpoints, base_path='')
+        if SWAGGER_12 in swagger_versions:
+            register_api_doc_endpoints(
+                config,
+                settings['pyramid_swagger.schema12'].get_api_doc_endpoints())
+
+        if SWAGGER_20 in swagger_versions:
+            register_api_doc_endpoints(
+                config,
+                [build_swagger_20_swagger_dot_json(config)],
+                base_path='')

--- a/pyramid_swagger/api.py
+++ b/pyramid_swagger/api.py
@@ -57,7 +57,7 @@ def build_swagger_12_resource_listing(resource_listing):
         return resource_listing
 
     return PyramidEndpoint(
-        path='/api-docs',
+        path='',
         route_name='pyramid_swagger.swagger12.api_docs',
         view=view_for_resource_listing,
         renderer='json')
@@ -76,7 +76,7 @@ def build_swagger_12_api_declaration(resource_name, api_declaration):
     # pyramid routes! (minus the leading /)
     route_name = 'pyramid_swagger.swagger12.apidocs-{0}'.format(resource_name)
     return PyramidEndpoint(
-        path='/api-docs/{0}'.format(resource_name),
+        path='/{0}'.format(resource_name),
         route_name=route_name,
         view=build_swagger_12_api_declaration_view(api_declaration),
         renderer='json')

--- a/pyramid_swagger/api.py
+++ b/pyramid_swagger/api.py
@@ -21,7 +21,7 @@ def register_api_doc_endpoints(config, endpoints, base_path='/api-docs'):
     :type  base_path: string
     """
     for endpoint in endpoints:
-        path = base_path + endpoint.path
+        path = base_path.rstrip('/') + endpoint.path
         config.add_route(endpoint.route_name, path)
         config.add_view(
             endpoint.view,
@@ -97,12 +97,12 @@ def build_swagger_12_api_declaration_view(api_declaration_json):
 
 def build_swagger_20_swagger_dot_json(config):
 
-    def view_for_swagger_json(request):
+    def view_for_swagger_dot_json(request):
         spec = config.registry.settings['pyramid_swagger.schema']
         return spec.spec_dict
 
     return PyramidEndpoint(
         path='/swagger.json',
         route_name='pyramid_swagger.swagger20.api_docs',
-        view=view_for_swagger_json,
+        view=view_for_swagger_dot_json,
         renderer='json')

--- a/pyramid_swagger/api.py
+++ b/pyramid_swagger/api.py
@@ -4,63 +4,81 @@ Module for automatically serving /api-docs* via Pyramid.
 """
 import simplejson
 
-
-def register_api_doc_endpoints(config):
-    """Create and register pyramid endpoints for /api-docs*."""
-    swagger_schema = config.registry.settings['pyramid_swagger.schema']
-    register_resource_listing(config, swagger_schema.resource_listing)
-
-    for name, filepath in swagger_schema.api_declarations.items():
-        with open(filepath) as input_file:
-            register_api_declaration(
-                config,
-                name,
-                simplejson.load(input_file)
-            )
+from pyramid_swagger.model import PyramidEndpoint
 
 
-def register_resource_listing(config, resource_listing):
-    """Registers the endpoint /api-docs.
+# TODO: document that this is now a public interface
+def register_api_doc_endpoints(config, endpoints, base_path='/api-docs'):
+    """Create and register pyramid endpoints to service swagger api docs.
+    Routes and views will be registered on the `config` at `path`.
 
-    :param config: Configurator instance for our webapp
-    :type config: pyramid Configurator
-    :param resource_listing: JSON representing a resource listing
+    :param config: a pyramid configuration to register the new views and routes
+    :type  config: :class:`pyramid.config.Configurator`
+    :param endpoints: a list of endpoints to register as routes and views
+    :type  endpoints: a list of :class:`pyramid_swagger.model.PyramidEndpoint`
+    :param base_path: the base path used to register api doc endpoints.
+        Defaults to `/api-docs`.
+    :type  base_path: string
+    """
+    for endpoint in endpoints:
+        path = base_path + endpoint.path
+        config.add_route(endpoint.route_name, path)
+        config.add_view(
+            endpoint.view,
+            route_name=endpoint.route_name,
+            renderer=endpoint.renderer)
+
+
+def build_swagger_12_endpoints(resource_listing, api_declarations):
+    """
+    :param resource_listing: JSON representing a Swagger 1.2 resource listing
     :type resource_listing: dict
+    :param api_declarations: JSON representing Swagger 1.2 api declarations
+    :type api_declarations: dict
+    :rtype: iterable of :class:`pyramid_swagger.model.PyramidEndpoint`
+    """
+    yield build_resource_listing(resource_listing)
+
+    for name, filepath in api_declarations.items():
+        with open(filepath) as input_file:
+            yield build_api_declaration(name, simplejson.load(input_file))
+
+
+def build_resource_listing(resource_listing):
+    """
+    :param resource_listing: JSON representing a Swagger 1.2 resource listing
+    :type resource_listing: dict
+    :rtype: :class:`pyramid_swagger.model.PyramidEndpoint`
     """
     def view_for_resource_listing(request):
         # Thanks to the magic of closures, this means we gracefully return JSON
         # without file IO at request time.
         return resource_listing
 
-    route_name = 'api_docs'
-    config.add_route(route_name, '/api-docs')
-    config.add_view(
-        view_for_resource_listing,
-        route_name=route_name,
-        renderer='json'
-    )
+    return PyramidEndpoint(
+        path='',
+        route_name='pyramid_swagger.swagger12.api_docs',
+        view=view_for_resource_listing,
+        renderer='json')
 
 
-def register_api_declaration(config, resource_name, api_declaration):
-    """Registers an endpoint at /api-docs.
-
-    :param config: Configurator instance for our webapp
-    :type config: pyramid Configurator
+def build_api_declaration(resource_name, api_declaration):
+    """
     :param resource_name: The `path` parameter from the resource listing for
         this resource.
     :type resource_name: string
-    :param api_declaration: JSON representing an api declaration
+    :param api_declaration: JSON representing a Swagger 1.2 api declaration
     :type api_declaration: dict
+    :rtype: :class:`pyramid_swagger.model.PyramidEndpoint`
     """
     # NOTE: This means our resource paths are currently constrained to be valid
     # pyramid routes! (minus the leading /)
-    route_name = 'apidocs-{0}'.format(resource_name)
-    config.add_route(route_name, '/api-docs/{0}'.format(resource_name))
-    config.add_view(
-        build_api_declaration_view(api_declaration),
+    route_name = 'pyramid_swagger.swagger12.apidocs-{0}'.format(resource_name)
+    return PyramidEndpoint(
+        path='/{0}'.format(resource_name),
         route_name=route_name,
-        renderer='json'
-    )
+        view=build_api_declaration_view(api_declaration),
+        renderer='json')
 
 
 def build_api_declaration_view(api_declaration_json):

--- a/pyramid_swagger/ingest.py
+++ b/pyramid_swagger/ingest.py
@@ -7,6 +7,7 @@ import os.path
 import simplejson
 from bravado_core.spec import Spec
 
+from .api import build_swagger_12_endpoints
 from .load_schema import load_schema
 from .model import SwaggerSchema
 from .spec import validate_swagger_schemas
@@ -124,7 +125,8 @@ def compile_swagger_schema(schema_dir, resource_listing):
     """
     mapping = build_schema_mapping(schema_dir, resource_listing)
     resource_validators = ingest_resources(mapping, schema_dir)
-    return SwaggerSchema(resource_listing, mapping, resource_validators)
+    endpoints = list(build_swagger_12_endpoints(resource_listing, mapping))
+    return SwaggerSchema(endpoints, resource_validators)
 
 
 def validate_swagger_schema(schema_dir, resource_listing):

--- a/pyramid_swagger/model.py
+++ b/pyramid_swagger/model.py
@@ -3,7 +3,13 @@
 The core model we use to represent the entire ingested swagger schema for this
 service.
 """
+from collections import namedtuple
 import re
+
+
+PyramidEndpoint = namedtuple(
+    'PyramidEndpoint',
+    'path route_name view renderer')
 
 
 class PathNotMatchedError(Exception):
@@ -18,24 +24,16 @@ class SwaggerSchema(object):
     and exposes methods for efficiently finding the relevant schemas for a
     Pyramid request.
 
-    :param resource_listing: A swagger resource listing
-    :type resource_listing: dict
-    :param api_declarations: Map from resource name to filepath of its api
-        declaration
-    :type api_declarations: dict
+    :param pyramid_endpoints: a list of :class:`PyramidEndpoint` which define
+        the pyramid endpoints to create for serving the api docs
     :param resource_validators: a list of resolvers, one per Swagger resource
     :type resource_validators: list of mappings from :class:`RequestMatcher`
         to :class:`ValidatorMap`
     for every operation in the api specification.
     """
 
-    def __init__(
-            self,
-            resource_listing,
-            api_declarations,
-            resource_validators):
-        self.resource_listing = resource_listing
-        self.api_declarations = api_declarations
+    def __init__(self, pyramid_endpoints, resource_validators):
+        self.pyramid_endpoints = pyramid_endpoints
         self.resource_validators = resource_validators
 
     def validators_for_request(self, request, **kwargs):
@@ -55,6 +53,9 @@ class SwaggerSchema(object):
             'Could not find the relevant path ({0}) in the Swagger schema. '
             'Perhaps you forgot to add it?'.format(request.path)
         )
+
+    def get_api_doc_endpoints(self):
+        return self.pyramid_endpoints
 
 
 def partial_path_match(path1, path2, kwarg_re=r'\{.*\}'):

--- a/pyramid_swagger/tween.py
+++ b/pyramid_swagger/tween.py
@@ -32,7 +32,7 @@ SUPPORTED_SWAGGER_VERSIONS = [SWAGGER_12, SWAGGER_20]
 DEFAULT_EXCLUDED_PATHS = [
     r'^/static/?',
     r'^/api-docs/?',
-    r'^/swagger.json'
+    r'^/swagger.json',
 ]
 
 

--- a/tests/acceptance/api_test.py
+++ b/tests/acceptance/api_test.py
@@ -6,41 +6,74 @@ from .app import main
 
 
 @pytest.fixture
-def test_app():
-    """Fixture for setting up a test test_app."""
-    settings = {
+def settings():
+    return {
         'pyramid_swagger.schema_directory': 'tests/sample_schemas/good_app/',
         'pyramid_swagger.enable_swagger_spec_validation': False,
     }
+
+
+@pytest.fixture
+def default_test_app(settings):
     return TestApp(main({}, **settings))
 
 
-@pytest.mark.xfail(reason='Swagger 1.2 only test')
-def test_api_docs(test_app):
-    test_app.get(
-        '/api-docs',
-        status=200,
-    )
+@pytest.fixture
+def swagger_20_test_app(settings):
+    """Fixture for setting up a Swagger 2.0 version of the test test_app."""
+    settings['pyramid_swagger.swagger_versions'] = ['2.0']
+    return TestApp(main({}, **settings))
 
 
-@pytest.mark.xfail(reason='Swagger 1.2 only test')
-def test_sample_resource(test_app):
-    test_app.get(
-        '/api-docs/sample',
-        status=200,
-    )
+@pytest.fixture
+def swagger_12_test_app(settings):
+    """Fixture for setting up a Swagger 1.2 version of the test test_app."""
+    settings['pyramid_swagger.swagger_versions'] = ['1.2']
+    return TestApp(main({}, **settings))
 
 
-@pytest.mark.xfail(reason='Swagger 1.2 only test')
-def test_other_sample_resource(test_app):
-    test_app.get(
-        '/api-docs/other_sample',
-        status=200,
-    )
+@pytest.fixture
+def swagger_12_and_20_test_app(settings):
+    """Fixture for setting up a Swagger 1.2 and Swagger 2.0 version of the
+    test test_app.
+    """
+    settings['pyramid_swagger.swagger_versions'] = ['1.2', '2.0']
+    return TestApp(main({}, **settings))
 
 
-def test_swagger_20_schema(test_app):
-    test_app.get(
-        '/swagger.json',
-        status=200,
-    )
+def test_12_api_docs(swagger_12_test_app):
+    response = swagger_12_test_app.get('/api-docs', status=200)
+    assert response.json['swaggerVersion'] == '1.2'
+
+
+def test_12_sample_resource(swagger_12_test_app):
+    response = swagger_12_test_app.get('/api-docs/sample', status=200)
+    assert response.json['swaggerVersion'] == '1.2'
+
+
+def test_12_other_sample_resource(swagger_12_test_app):
+    response = swagger_12_test_app.get('/api-docs/other_sample', status=200)
+    assert response.json['swaggerVersion'] == '1.2'
+
+
+def test_20_schema(swagger_20_test_app):
+    response = swagger_20_test_app.get('/swagger.json', status=200)
+    assert response.json['swagger'] == '2.0'
+
+
+def test_12_and_20_schemas(swagger_12_and_20_test_app):
+    for path in ('/api-docs', '/api-docs/sample', '/api-docs/other_sample'):
+        response12 = swagger_12_and_20_test_app.get(path, status=200)
+        assert response12.json['swaggerVersion'] == '1.2'
+
+    response20 = swagger_12_and_20_test_app.get('/swagger.json', status=200)
+    assert response20.json['swagger'] == '2.0'
+
+
+def test_default_only_serves_up_swagger_20_schema(default_test_app):
+    response = default_test_app.get('/swagger.json', status=200)
+    assert response.json['swagger'] == '2.0'
+
+    # swagger 1.2 schemas should 404
+    for path in ('/api-docs', '/api-docs/sample', '/api-docs/other_sample'):
+        default_test_app.get(path, status=404)

--- a/tests/acceptance/request_test.py
+++ b/tests/acceptance/request_test.py
@@ -200,7 +200,6 @@ def test_200_skip_validation_with_excluded_path():
         .status_code == 200
 
 
-@pytest.mark.xfail(reason='Why?')
 def test_200_skip_validation_when_disabled():
     # calling endpoint with required args missing
     request = test_app(**{

--- a/tests/acceptance/request_test.py
+++ b/tests/acceptance/request_test.py
@@ -1,13 +1,16 @@
 # -*- coding: utf-8 -*-
 from contextlib import contextmanager
+from _pytest.python import FixtureRequest
 
+from mock import Mock
 from pyramid.httpexceptions import exception_response
 import pytest
 import simplejson
 
 
-@pytest.fixture
-def test_app(**overrides):
+# Parameterize pyramid_swagger.swagger_versions
+@pytest.fixture(params=[['1.2'], ['2.0'], ['1.2', '2.0']])
+def test_app(request, **overrides):
     """Fixture for setting up a test test_app with particular settings."""
     from .app import main
     from webtest import TestApp
@@ -15,7 +18,8 @@ def test_app(**overrides):
         'pyramid_swagger.schema_directory': 'tests/sample_schemas/good_app/',
         'pyramid_swagger.enable_request_validation': True,
         'pyramid_swagger.enable_response_validation': False,
-        'pyramid_swagger.enable_swagger_spec_validation': False},
+        'pyramid_swagger.enable_swagger_spec_validation': False,
+        'pyramid_swagger.swagger_versions': request.param},
         **overrides
     )
     return TestApp(main({}, **settings))
@@ -195,22 +199,30 @@ def test_200_with_required_header(test_app):
 
 
 def test_200_skip_validation_with_excluded_path():
-    assert test_app(**{'pyramid_swagger.exclude_paths': [r'^/sample/?']}) \
-        .get('/sample/test_request/resource') \
-        .status_code == 200
+    app = test_app(
+        request=Mock(spec=FixtureRequest, param=['2.0']),
+        **{'pyramid_swagger.exclude_paths': [r'^/sample/?']}
+    )
+    assert app.get('/sample/test_request/resource').status_code == 200
 
 
 def test_200_skip_validation_when_disabled():
     # calling endpoint with required args missing
-    request = test_app(**{
+    overrides = {
         'pyramid_swagger.enable_request_validation': False,
         'skip_swagger_data_assert': True,
-    }).get('/get_with_non_string_query_args', params={})
-    assert request.status_code == 200
+    }
+    app = test_app(
+        request=Mock(spec=FixtureRequest, param=['2.0']),
+        **overrides
+    )
+    response = app.get('/get_with_non_string_query_args', params={})
+    assert response.status_code == 200
 
 
 def test_path_validation_context():
     app = test_app(
+        request=Mock(spec=FixtureRequest, param=['2.0']),
         **{'pyramid_swagger.validation_context_path': validation_ctx_path}
     )
     assert app.get('/does_not_exist').status_code == 206
@@ -218,6 +230,7 @@ def test_path_validation_context():
 
 def test_request_validation_context():
     app = test_app(
+        request=Mock(spec=FixtureRequest, param=['2.0']),
         **{'pyramid_swagger.validation_context_path': validation_ctx_path})
     response = app.get('/get_with_non_string_query_args', params={})
     assert response.status_code == 206

--- a/tests/acceptance/response20_test.py
+++ b/tests/acceptance/response20_test.py
@@ -4,6 +4,7 @@
 # Based on request_test.py (Swagger 1.2 tests). Differences made it hard for
 # a single codebase to exercise both Swagger 1.2 and 2.0 responses.
 #
+from _pytest.python import FixtureRequest
 from mock import patch, Mock
 from pyramid.interfaces import IRoutesMapper
 from pyramid.response import Response
@@ -194,7 +195,9 @@ def test_200_for_good_validated_array_response():
 
 
 def test_200_for_normal_response_validation():
-    assert test_app(**{'pyramid_swagger.enable_response_validation': True}) \
+    assert test_app(
+        request=Mock(spec=FixtureRequest, param=['2.0']),
+        **{'pyramid_swagger.enable_response_validation': True}) \
         .post_json('/sample', {'foo': 'test', 'bar': 'test'}) \
         .status_code == 200
 
@@ -205,7 +208,9 @@ def test_app_error_if_path_not_in_spec_and_path_validation_disabled():
     HTTPNotFound exception.
     """
     with pytest.raises(AppError):
-        assert test_app(**{'pyramid_swagger.enable_path_validation': False}) \
+        assert test_app(
+            request=Mock(spec=FixtureRequest, param=['2.0']),
+            **{'pyramid_swagger.enable_path_validation': False}) \
             .get('/this/path/doesnt/exist')
 
 

--- a/tests/acceptance/response20_test.py
+++ b/tests/acceptance/response20_test.py
@@ -37,7 +37,8 @@ def _validate_against_tween(request, response=None, path_pattern='/',
     settings = dict({
         'pyramid_swagger.schema_directory': 'tests/sample_schemas/good_app/',
         'pyramid_swagger.enable_swagger_spec_validation': False,
-        'pyramid_swagger.enable_response_validation': True},
+        'pyramid_swagger.enable_response_validation': True,
+        'pyramid_swagger.swagger_versions': ['2.0']},
         **overrides
     )
 

--- a/tests/acceptance/response_test.py
+++ b/tests/acceptance/response_test.py
@@ -75,7 +75,7 @@ def _validate_against_tween(request, response=None, **overrides):
         return response or Response()
 
     settings = dict({
-        'pyramid_swagger.swagger_version': '1.2',
+        'pyramid_swagger.swagger_versions': ['1.2'],
         'pyramid_swagger.enable_swagger_spec_validation': False,
         'pyramid_swagger.schema_directory': 'tests/sample_schemas/good_app/'},
         **overrides

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -3,7 +3,7 @@ import mock
 import pytest
 from pyramid.testing import DummyRequest
 
-from pyramid_swagger.api import build_api_declaration_view
+from pyramid_swagger.api import build_swagger_12_api_declaration_view
 from pyramid_swagger.api import register_api_doc_endpoints
 from pyramid_swagger.ingest import API_DOCS_FILENAME
 from pyramid_swagger.ingest import ApiDeclarationNotFoundError
@@ -14,7 +14,7 @@ from tests.acceptance.response_test import get_swagger_schema
 
 def test_basepath_rewriting():
     resource_json = {'basePath': 'bar'}
-    view = build_api_declaration_view(resource_json)
+    view = build_swagger_12_api_declaration_view(resource_json)
     request = DummyRequest(application_url='foo')
     result = view(request)
     assert result['basePath'] == request.application_url

--- a/tests/ingest_test.py
+++ b/tests/ingest_test.py
@@ -39,7 +39,7 @@ def test_get_swagger_schema_default():
     }
 
     swagger_schema = get_swagger_schema(settings)
-    assert swagger_schema.resource_listing
+    assert len(swagger_schema.pyramid_endpoints) == 4
     assert swagger_schema.resource_validators
 
 


### PR DESCRIPTION
Still have some unit tests to write but the core of the functionality is there.

General notes:
- Merged in dnephin's branch from https://github.com/striglia/pyramid_swagger/pull/95
- I used a parameterized pytest fixture in `tests/acceptance/request_test.py` to exercise code paths for the variations of `pyramid_swagger.swagger_versions`. Was not able to do with with `response_test.py` hence `response20_test.py`
- Tested with a pyramid app using swaggerpy as a 1.2 client, and bravado as a 2.0 client
