### PR TITLE
Pin Tox version to 1.9.2 to prevent Travis picking up 2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
 - TOX_ENV=docs
 - TOX_ENV=pep8
 install:
-- pip install --use-mirrors tox coveralls
+- pip install --use-mirrors tox==1.9.2 coveralls
 script:
 - tox -e $TOX_ENV
 after_success: coveralls


### PR DESCRIPTION
Builds like [this](https://travis-ci.org/striglia/pyramid_swagger/builds/62315510) were failing as Travis was picking 2.0.0 tox version and throwing encoding errors. Still need to figure out the root cause.