### PR TITLE
Add pyramid_swagger.use_models config key

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+2.0.0-rc3 (2015-XX-XX)
+++++++++++++++++++++++
+* Added pyramid_swagger.use_models config setting for Swagger 2.0 backwards compatibility with existing Swagger 1.2 views
+
 2.0.0-rc2 (2015-05-26)
 ++++++++++++++++++++++
 * Upgraded bravado-core to 1.0.0-rc1 so basePath is used when matching a request to an operation

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,7 +3,7 @@ Changelog
 
 2.0.0-rc3 (2015-XX-XX)
 ++++++++++++++++++++++
-* Added pyramid_swagger.use_models config setting for Swagger 2.0 backwards compatibility with existing Swagger 1.2 views
+* Added ``use_models`` configuration option for Swagger 2.0 backwards compatibility with existing Swagger 1.2 views
 
 2.0.0-rc2 (2015-05-26)
 ++++++++++++++++++++++

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,7 +3,7 @@ Changelog
 
 2.0.0-rc3 (2015-XX-XX)
 ++++++++++++++++++++++
-* Added ``use_models`` configuration option for Swagger 2.0 backwards compatibility with existing Swagger 1.2 views
+* Added ``use_models`` configuration option for Swagger 2.0 backwards compatibility with existing pyramid views
 
 2.0.0-rc2 (2015-05-26)
 ++++++++++++++++++++++

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -43,6 +43,11 @@ A few relevant settings for your `Pyramid .ini file <http://docs.pylonsproject.o
         # Default: True
         pyramid_swagger.enable_path_validation = True
 
+        # Use Python classes instead of dicts to represent models in incoming
+        # requests.
+        # Default: Whatever the default is in bravado_core, currently True
+        pyramid_swagger.use_models = True
+
         # Exclude certain endpoints from validation. Takes a list of regular
         # expressions.
         # Default: [r'^/static/?', r'^/api-docs/?, r'^/swagger.json']

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -45,8 +45,8 @@ A few relevant settings for your `Pyramid .ini file <http://docs.pylonsproject.o
 
         # Use Python classes instead of dicts to represent models in incoming
         # requests.
-        # Default: Whatever the default is in bravado_core, currently True
-        pyramid_swagger.use_models = True
+        # Default: False
+        pyramid_swagger.use_models = False
 
         # Exclude certain endpoints from validation. Takes a list of regular
         # expressions.

--- a/docs/migrating_to_swagger_20.rst
+++ b/docs/migrating_to_swagger_20.rst
@@ -3,13 +3,12 @@ Migrating to Swagger 2.0
 
 So you're using pyramid_swagger with Swagger 1.2 and now it is time to upgrade to Swagger 2.0.
 
-Just set the version of Swagger to support via configuration. Also, set ``use_models`` to ``false`` so that your existing Swagger 1.2 views will continue to received models in incoming requests as dicts instead of Python classes.
+Just set the version of Swagger to support via configuration.
 
 .. code-block:: ini
 
         [app:main]
         pyramid_swagger.swagger_versions = ['2.0']
-        pyramid_swagger.use_models = false
 
 If you would like to continue servicing Swagger 1.2 clients, pyramid_swagger has you covered.
 
@@ -17,7 +16,6 @@ If you would like to continue servicing Swagger 1.2 clients, pyramid_swagger has
 
         [app:main]
         pyramid_swagger.swagger_versions = ['1.2', '2.0']
-        pyramid_swagger.use_models = false
 
 .. note::
 
@@ -31,7 +29,6 @@ If you're not using an ini file, configuration in Python also works.
     def main(global_config, **settings):
         # ...
         settings['pyramid_swagger.swagger_versions'] = ['2.0']
-        settings['pyramid_swagger.use_models'] = False
         # ...and so on with the other settings...
         config = Configurator(settings=settings)
         config.include('pyramid_swagger')

--- a/docs/migrating_to_swagger_20.rst
+++ b/docs/migrating_to_swagger_20.rst
@@ -3,7 +3,7 @@ Migrating to Swagger 2.0
 
 So you're using pyramid_swagger with Swagger 1.2 and now it is time to upgrade to Swagger 2.0.
 
-Just set the version of Swagger to support via configuration. Also, set use_models to false so that your existing Swagger 1.2 views will continue to received models in incoming requests as dicts instead of Python classes.
+Just set the version of Swagger to support via configuration. Also, set ``use_models`` to ``false`` so that your existing Swagger 1.2 views will continue to received models in incoming requests as dicts instead of Python classes.
 
 .. code-block:: ini
 

--- a/docs/migrating_to_swagger_20.rst
+++ b/docs/migrating_to_swagger_20.rst
@@ -3,12 +3,13 @@ Migrating to Swagger 2.0
 
 So you're using pyramid_swagger with Swagger 1.2 and now it is time to upgrade to Swagger 2.0.
 
-Just set the version of Swagger to support via configuration like so:
+Just set the version of Swagger to support via configuration. Also, set use_models to false so that your existing Swagger 1.2 views will continue to received models in incoming requests as dicts instead of Python classes.
 
 .. code-block:: ini
 
         [app:main]
         pyramid_swagger.swagger_versions = ['2.0']
+        pyramid_swagger.use_models = false
 
 If you would like to continue servicing Swagger 1.2 clients, pyramid_swagger has you covered.
 
@@ -16,6 +17,7 @@ If you would like to continue servicing Swagger 1.2 clients, pyramid_swagger has
 
         [app:main]
         pyramid_swagger.swagger_versions = ['1.2', '2.0']
+        pyramid_swagger.use_models = false
 
 .. note::
 
@@ -29,6 +31,7 @@ If you're not using an ini file, configuration in Python also works.
     def main(global_config, **settings):
         # ...
         settings['pyramid_swagger.swagger_versions'] = ['2.0']
+        settings['pyramid_swagger.use_models'] = False
         # ...and so on with the other settings...
         config = Configurator(settings=settings)
         config.include('pyramid_swagger')

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -79,8 +79,28 @@ Example:
 The raw values (not-casted to any type) are still available from their
 usual place on the request (`matchdict`, `GET`, `POST`, `json()`, etc)
 
-If you have ``pyramid_swagger.use_models`` enabled, you can interact with
+If you have ``pyramid_swagger.use_models`` set to true, you can interact with
 models defined in ``#/definitions`` as Python classes instead of dicts.
+
+.. code-block:: json
+
+    {
+      "swagger": "2.0",
+      "definitions": {
+        "User": {
+          "type": "object",
+          "properties": {
+            "first_name": {
+              "type": "string"
+            },
+            "last_name": {
+              "type": "string"
+            }
+          }
+        }
+      }
+      ...
+    }
 
 .. code-block:: python
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -104,7 +104,7 @@ models defined in ``#/definitions`` as Python classes instead of dicts.
 
 .. code-block:: python
 
-    @view_config(route_name='add.user)
+    @view_config(route_name='add.user')
     def add_user(request):
         user = request.swagger_data['user']
         assert isinstance(user, bravado_core.models.User)
@@ -115,7 +115,7 @@ Otherwise, models are represented as dicts.
 
 .. code-block:: python
 
-    @view_config(route_name='add.user)
+    @view_config(route_name='add.user')
     def add_user(request):
         user = request.swagger_data['user']
         assert isinstance(user, dict)

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -79,6 +79,28 @@ Example:
 The raw values (not-casted to any type) are still available from their
 usual place on the request (`matchdict`, `GET`, `POST`, `json()`, etc)
 
+If you have ``pyramid_swagger.use_models`` enabled, you can interact with
+models defined in ``#/definitions`` as Python classes instead of dicts.
+
+.. code-block:: python
+
+    @view_config(route_name='add.user)
+    def add_user(request):
+        user = request.swagger_data['user']
+        assert isinstance(user, bravado_core.models.User)
+        first_name = user.first_name
+        ...
+
+Otherwise, models are represented as dicts.
+
+.. code-block:: python
+
+    @view_config(route_name='add.user)
+    def add_user(request):
+        user = request.swagger_data['user']
+        assert isinstance(user, dict)
+        first_name = user['first_name']
+        ...
 
 .. note::
 

--- a/pyramid_swagger/ingest.py
+++ b/pyramid_swagger/ingest.py
@@ -195,10 +195,14 @@ def create_bravado_core_config(settings):
         'pyramid_swagger.use_models': 'use_models'
     }
 
-    return dict(
+    bravado_core_config_defaults = {
+        'use_models': False
+    }
+
+    return dict(bravado_core_config_defaults, **dict(
         (bravado_core_key, settings[pyramid_swagger_key])
         for pyramid_swagger_key, bravado_core_key in config_keys.iteritems()
-        if pyramid_swagger_key in settings)
+        if pyramid_swagger_key in settings))
 
 
 def ingest_resources(mapping, schema_dir):

--- a/pyramid_swagger/ingest.py
+++ b/pyramid_swagger/ingest.py
@@ -36,12 +36,18 @@ def find_resource_paths(schema_dir):
     def not_api_doc_file(filename):
         return not filename.endswith(API_DOCS_FILENAME)
 
+    def not_swagger_dot_json(filename):
+        # Exclude a Swagger 2.0 schema file if it happens to exist.
+        return not os.path.basename(filename) == 'swagger.json'
+
     def filename_to_path(filename):
         filename, _ext = os.path.splitext(os.path.basename(filename))
         return '/' + filename
 
     filenames = glob.glob('{0}/*.json'.format(schema_dir))
-    return map(filename_to_path, filter(not_api_doc_file, sorted(filenames)))
+    return map(filename_to_path,
+               filter(not_swagger_dot_json,
+                      filter(not_api_doc_file, sorted(filenames))))
 
 
 def build_schema_mapping(schema_dir, resource_listing):
@@ -164,16 +170,35 @@ def get_swagger_spec(settings):
     with open(os.path.join(schema_dir, 'swagger.json'), 'r') as f:
         spec_dict = simplejson.loads(f.read())
 
-    spec_config = {
-        'validate_requests':
-            settings.get('pyramid_swagger.enable_request_validation'),
-        'validate_responses':
-            settings.get('pyramid_swagger.enable_response_validation'),
-        'validate_swagger_spec':
-            settings.get('pyramid_swagger.enable_swagger_spec_validation'),
+    return Spec.from_dict(
+        spec_dict,
+        config=create_bravado_core_config(settings))
+
+
+def create_bravado_core_config(settings):
+    """Create a configuration dict for bravado_core based on pyramid_swagger
+    settings.
+
+    :param settings: pyramid registry settings with configuration for
+        building a swagger schema
+    :type settings: dict
+    :returns: config dict suitable for passing into
+        bravado_core.spec.Spec.from_dict(..)
+    :rtype: dict
+    """
+    # Map pyramid_swagger config key -> bravado_core config key
+    config_keys = {
+        'pyramid_swagger.enable_request_validation': 'validate_requests',
+        'pyramid_swagger.enable_response_validation': 'validate_responses',
+        'pyramid_swagger.enable_swagger_spec_validation':
+            'validate_swagger_spec',
+        'pyramid_swagger.use_models': 'use_models'
     }
-    spec = Spec.from_dict(spec_dict, config=spec_config)
-    return spec
+
+    return dict(
+        (bravado_core_key, settings[pyramid_swagger_key])
+        for pyramid_swagger_key, bravado_core_key in config_keys.iteritems()
+        if pyramid_swagger_key in settings)
 
 
 def ingest_resources(mapping, schema_dir):

--- a/tests/ingest_test.py
+++ b/tests/ingest_test.py
@@ -99,9 +99,8 @@ def test_get_resource_listing_default():
         assert resource_listing == simplejson.load(fh)
 
 
-def test_create_bravado_core_config_empty():
-    bravado_core_config = create_bravado_core_config({})
-    assert len(bravado_core_config) == 0
+def test_create_bravado_core_config_with_defaults():
+    assert {'use_models': False} == create_bravado_core_config({})
 
 
 def test_create_bravado_core_config_non_empty():
@@ -109,13 +108,13 @@ def test_create_bravado_core_config_non_empty():
         'pyramid_swagger.enable_request_validation': True,
         'pyramid_swagger.enable_response_validation': False,
         'pyramid_swagger.enable_swagger_spec_validation': True,
-        'pyramid_swagger.use_models': False,
+        'pyramid_swagger.use_models': True,
     }
     expected_bravado_core_config = {
         'validate_requests': True,
         'validate_responses': False,
         'validate_swagger_spec': True,
-        'use_models': False
+        'use_models': True
     }
     bravado_core_config = create_bravado_core_config(pyramid_swagger_config)
     assert expected_bravado_core_config == bravado_core_config

--- a/tests/ingest_test.py
+++ b/tests/ingest_test.py
@@ -6,6 +6,7 @@ import pytest
 import simplejson
 
 from pyramid_swagger.ingest import API_DOCS_FILENAME
+from pyramid_swagger.ingest import create_bravado_core_config
 from pyramid_swagger.ingest import _load_resource_listing
 from pyramid_swagger.ingest import generate_resource_listing
 from pyramid_swagger.ingest import get_swagger_schema
@@ -52,7 +53,6 @@ def test_get_swagger_schema_no_validation():
     get_swagger_schema(settings)
 
 
-@pytest.mark.xfail(reason='Remove 1.2 test')
 def test_generate_resource_listing():
     listing = {'swaggerVersion': 1.2}
 
@@ -97,3 +97,25 @@ def test_get_resource_listing_default():
 
     with open(os.path.join(schema_dir, 'api_docs.json')) as fh:
         assert resource_listing == simplejson.load(fh)
+
+
+def test_create_bravado_core_config_empty():
+    bravado_core_config = create_bravado_core_config({})
+    assert len(bravado_core_config) == 0
+
+
+def test_create_bravado_core_config_non_empty():
+    pyramid_swagger_config = {
+        'pyramid_swagger.enable_request_validation': True,
+        'pyramid_swagger.enable_response_validation': False,
+        'pyramid_swagger.enable_swagger_spec_validation': True,
+        'pyramid_swagger.use_models': False,
+    }
+    expected_bravado_core_config = {
+        'validate_requests': True,
+        'validate_responses': False,
+        'validate_swagger_spec': True,
+        'use_models': False
+    }
+    bravado_core_config = create_bravado_core_config(pyramid_swagger_config)
+    assert expected_bravado_core_config == bravado_core_config


### PR DESCRIPTION
This adds a new config key to pyramid_swagger and passes it on to bravado-core.  When ```use_models``` is set to ```False```, models are not generated from the incoming request. This retains compatibility with existing Swagger 1.2 views where models are represented as dicts.