### PR TITLE
Don't attempt to validate error responses

### DIFF
--- a/pyramid_swagger/tween.py
+++ b/pyramid_swagger/tween.py
@@ -352,6 +352,11 @@ def validate_response(response, validator):
         response.body in (None, b'', b'{}', b'null')
     ):
         return
+
+    # Don't attempt to validate non-success responses
+    if not 200 <= response.status_code <= 203:
+        return
+
     validator.validate(prepare_body(response))
 
 

--- a/tests/tween_test.py
+++ b/tests/tween_test.py
@@ -112,6 +112,17 @@ def test_validation_content_type_with_json():
     fake_validator.validate.assert_called_once_with(body)
 
 
+def test_skips_validating_errors():
+    fake_schema = mock.Mock(response_body_schema={'type': 'string'})
+    fake_validator = mock.Mock(schema=fake_schema)
+    response = Response(
+        body='abe1351f',
+        status_code=403,
+    )
+    validate_response(response, fake_validator)
+    assert not fake_validator.validate.called
+
+
 def test_raw_string():
     fake_schema = mock.Mock(response_body_schema={'type': 'string'})
     fake_validator = mock.Mock(schema=fake_schema)


### PR DESCRIPTION
When response validation is enabled, error responses are validated against the normal response type, often producing errors. Instead, we should not validate error responses, as in Swagger 1.2, the types of error messages are not well defined.

I'm not able to create a PR against 1.5.0 because there is no branch on GitHub for it; instead, see the comparison against the 1.5.0-rc2 tag for a usefull diff: https://github.com/striglia/pyramid_swagger/compare/striglia:v1.5.0-rc2...chriskuehl:dont-validate-error-responses