### PR TITLE
Don't attempt to validate error responses

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+1.5.1 (2015-06-17)
+++++++++++++++++++++++
+
+* No longer attempts to validate error responses, which typically don't follow
+  the same format as successful responses. (Closes: #121)
+
 1.5.0 (2015-05-12)
 ++++++++++++++++++++++
 

--- a/pyramid_swagger/__about__.py
+++ b/pyramid_swagger/__about__.py
@@ -13,7 +13,7 @@ __title__ = "pyramid_swagger"
 __summary__ = "Swagger tools for use in pyramid webapps"
 __uri__ = "https://github.com/striglia/pyramid_swagger"
 
-__version__ = "1.5.0"
+__version__ = "1.5.1"
 
 __author__ = "Scott Triglia"
 __email__ = "scott.triglia@gmail.com"

--- a/pyramid_swagger/tween.py
+++ b/pyramid_swagger/tween.py
@@ -352,6 +352,11 @@ def validate_response(response, validator):
         response.body in (None, b'', b'{}', b'null')
     ):
         return
+
+    # Don't attempt to validate non-success responses
+    if not 200 <= response.status_code <= 203:
+        return
+
     validator.validate(prepare_body(response))
 
 

--- a/tests/tween_test.py
+++ b/tests/tween_test.py
@@ -112,6 +112,17 @@ def test_validation_content_type_with_json():
     fake_validator.validate.assert_called_once_with(body)
 
 
+def test_skips_validating_errors():
+    fake_schema = mock.Mock(response_body_schema={'type': 'string'})
+    fake_validator = mock.Mock(schema=fake_schema)
+    response = Response(
+        body='abe1351f',
+        status_code=403,
+    )
+    validate_response(response, fake_validator)
+    assert not fake_validator.validate.called
+
+
 def test_raw_string():
     fake_schema = mock.Mock(response_body_schema={'type': 'string'})
     fake_validator = mock.Mock(schema=fake_schema)


### PR DESCRIPTION
When response validation is enabled, error responses are validated against the normal response type, often producing errors. Instead, we should not validate error responses, as in Swagger 1.2, the types of error messages are not well defined. This fixes #121.

This is a rebase of #122 onto the new swagger_12 branch. GitHub doesn't let you switch the branches involved in a pull request (boo) so here's a new PR.