### PR TITLE
Send absolute swagger spec url to bravado-core

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,10 +1,11 @@
 Changelog
 =========
 
-2.1.0 (2015-08-06)
+2.1.0 (2015-08-14)
 ++++++++++++++++++++++
 * Added ``user_formats`` configuration option to provide user-defined formats which can be used for validations
   and conversions to wire-python-wire formats. (See :ref:`user-format-label`)
+* Added support for relative cross-refs in Swagger v2.0 specs.
 
 2.0.0 (2015-06-25)
 ++++++++++++++++++++++

--- a/pyramid_swagger/ingest.py
+++ b/pyramid_swagger/ingest.py
@@ -6,6 +6,7 @@ import os.path
 
 import simplejson
 from bravado_core.spec import Spec
+from six.moves.urllib import parse as urlparse
 
 from .api import build_swagger_12_endpoints
 from .load_schema import load_schema
@@ -167,12 +168,16 @@ def get_swagger_spec(settings):
     :rtype: :class:`bravado_core.spec.Spec`
     """
     schema_dir = settings.get('pyramid_swagger.schema_directory', 'api_docs/')
-    with open(os.path.join(schema_dir, 'swagger.json'), 'r') as f:
+    schema_path = os.path.join(schema_dir, 'swagger.json')
+    schema_url = urlparse.urljoin('file:', os.path.abspath(schema_path))
+
+    with open(schema_path, 'r') as f:
         spec_dict = simplejson.loads(f.read())
 
     return Spec.from_dict(
         spec_dict,
-        config=create_bravado_core_config(settings))
+        config=create_bravado_core_config(settings),
+        origin_url=schema_url)
 
 
 def create_bravado_core_config(settings):

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     packages=find_packages(exclude=["contrib", "docs", "tests*"]),
     include_package_data=True,
     install_requires=[
-        'bravado-core >= 2.1.0',
+        'bravado-core >= 2.4.0',
         'jsonschema',
         'pyramid<1.6.0a',
         'simplejson',

--- a/tests/acceptance/relative_ref_test.py
+++ b/tests/acceptance/relative_ref_test.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+import pytest
+from webtest import TestApp
+
+from .app import main
+
+
+@pytest.fixture
+def settings():
+    dir_path = 'tests/sample_schemas/relative_ref/'
+    return {
+        'pyramid_swagger.schema_directory': dir_path,
+        'pyramid_swagger.enable_request_validation': True,
+        'pyramid_swagger.enable_swagger_spec_validation': True,
+    }
+
+
+@pytest.fixture
+def test_app(settings):
+    """Fixture for setting up a Swagger 2.0 version of the test test_app."""
+    settings['pyramid_swagger.swagger_versions'] = ['2.0']
+    return TestApp(main({}, **settings))
+
+
+def test_running_query_for_relative_ref(test_app):
+    response = test_app.get('/sample/path_arg1/resource', params={},)
+    assert response.status_code == 200

--- a/tests/ingest_test.py
+++ b/tests/ingest_test.py
@@ -10,6 +10,7 @@ from pyramid_swagger.ingest import create_bravado_core_config
 from pyramid_swagger.ingest import _load_resource_listing
 from pyramid_swagger.ingest import generate_resource_listing
 from pyramid_swagger.ingest import get_swagger_schema
+from pyramid_swagger.ingest import get_swagger_spec
 from pyramid_swagger.ingest import get_resource_listing
 from pyramid_swagger.ingest import ingest_resources
 from pyramid_swagger.ingest import ApiDeclarationNotFoundError
@@ -32,6 +33,19 @@ def test_proper_error_on_missing_api_declaration():
             'fake',
         )
     assert 'fake/sample_resource.json' in str(exc)
+
+
+@mock.patch('six.moves.builtins.open', return_value=mock.MagicMock())
+@mock.patch('os.path.abspath', return_value='/bar/foo/swagger.json')
+@mock.patch('simplejson.loads', return_value=mock.Mock(spec=dict))
+@mock.patch('pyramid_swagger.ingest.Spec.from_dict')
+def test_get_swagger_spec_passes_absolute_url(mock_spec, mock_simple,
+                                              mock_abs, mock_open):
+    get_swagger_spec({'pyramid_swagger.schema_directory': 'foo/'})
+    mock_abs.assert_called_once_with('foo/swagger.json')
+    expected_url = "file:///bar/foo/swagger.json"
+    mock_spec.assert_called_once_with(mock.ANY, config=mock.ANY,
+                                      origin_url=expected_url)
 
 
 def test_get_swagger_schema_default():

--- a/tests/sample_schemas/relative_ref/parameters/common.json
+++ b/tests/sample_schemas/relative_ref/parameters/common.json
@@ -1,0 +1,9 @@
+{
+    "path_arg": {
+        "in": "path",
+        "name": "path_arg",
+        "required": true,
+        "type": "string",
+        "enum": ["path_arg1", "path_arg2"]
+    }
+}

--- a/tests/sample_schemas/relative_ref/paths/common.json
+++ b/tests/sample_schemas/relative_ref/paths/common.json
@@ -1,0 +1,29 @@
+{
+    "no_models": {
+      "get": {
+        "responses": {
+          "200": {
+              "$ref": "../responses/common.json#/200"
+          }
+        },
+        "description": "",
+        "operationId": "no_models_get"
+      }
+    },
+    "sample_resource": {
+      "get": {
+        "responses": {
+          "200": {
+              "$ref": "../responses/common.json#/200"
+          }
+        },
+        "description": "",
+        "operationId": "standard",
+        "parameters": [
+          {
+            "$ref": "../parameters/common.json#/path_arg"
+          }
+        ]
+      }
+    }
+}

--- a/tests/sample_schemas/relative_ref/responses/common.json
+++ b/tests/sample_schemas/relative_ref/responses/common.json
@@ -1,0 +1,21 @@
+{
+    "200": {
+      "description": "Return a standard_response",
+      "schema": {
+          "type": "object",
+          "required": [
+            "raw_response",
+            "logging_info"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "raw_response": {
+              "type": "string"
+            },
+            "logging_info": {
+              "type": "object"
+            }
+          }
+      }
+    }
+}

--- a/tests/sample_schemas/relative_ref/swagger.json
+++ b/tests/sample_schemas/relative_ref/swagger.json
@@ -1,0 +1,20 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Title was not specified",
+    "version": "0.1"
+  },
+  "produces": ["application/json"],
+  "paths": {
+    "/no_models": {
+        "$ref": "paths/common.json#/no_models"
+    },
+    "/sample/{path_arg}/resource": {
+        "$ref": "paths/common.json#/sample_resource"
+    }
+  },
+  "host": "localhost:9999",
+  "schemes": [
+    "http"
+  ]
+}


### PR DESCRIPTION
- Send absolute url to `Spec.from_dict` so that 'relative' `$ref`  get resolved relative to the absolute url of `swagger.json` spec.
- Fixes #131