### PR TITLE
Upgrade bravado-core dependency to 3.0.2

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+2.2.2 (2015-XX-XX)
+++++++++++++++++++++++
+* Upgrade to bravado-core 3.0.2 which includes a change in the way user-defined formats are registered.
+
 2.2.1 (2015-08-20)
 ++++++++++++++++++++++
 * No longer attempts to validate error responses, which typically don't follow

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -104,7 +104,7 @@ Sample usage:
 
 
 ``user_format`` used above is an instance of
-:class:`bravado_core.formatter.SwaggerFormat` (`ref <http://bravado-core.readthedocs.org/en/latest/bravado_core.html#bravado_core.formatter.SwaggerFormat>`_) and can be defined like this:
+:class:`bravado_core.formatter.SwaggerFormat` and can be defined like this:
 
 .. code-block:: python
 

--- a/pyramid_swagger/__init__.py
+++ b/pyramid_swagger/__init__.py
@@ -7,8 +7,7 @@ import pyramid
 from .api import register_api_doc_endpoints, build_swagger_20_swagger_dot_json
 from .ingest import get_swagger_schema
 from .ingest import get_swagger_spec
-from .tween import (
-    get_swagger_versions, register_user_formatters, SWAGGER_12, SWAGGER_20)
+from .tween import get_swagger_versions, SWAGGER_12, SWAGGER_20
 
 
 def includeme(config):
@@ -29,7 +28,6 @@ def includeme(config):
 
     if SWAGGER_20 in swagger_versions:
         settings['pyramid_swagger.schema20'] = get_swagger_spec(settings)
-        register_user_formatters(settings)
 
     config.add_tween(
         "pyramid_swagger.tween.validation_tween_factory",

--- a/pyramid_swagger/ingest.py
+++ b/pyramid_swagger/ingest.py
@@ -197,7 +197,8 @@ def create_bravado_core_config(settings):
         'pyramid_swagger.enable_response_validation': 'validate_responses',
         'pyramid_swagger.enable_swagger_spec_validation':
             'validate_swagger_spec',
-        'pyramid_swagger.use_models': 'use_models'
+        'pyramid_swagger.use_models': 'use_models',
+        'pyramid_swagger.user_formats': 'formats',
     }
 
     bravado_core_config_defaults = {

--- a/pyramid_swagger/tween.py
+++ b/pyramid_swagger/tween.py
@@ -51,7 +51,7 @@ class Settings(namedtuple(
     ]
 )):
 
-    """A settings object for configuratble options.
+    """A settings object for configurable options.
 
     :param swagger12_handler: a :class:`SwaggerHandler` for v1.2 or None
     :param swagger20_handler: a :class:`SwaggerHandler` for v2.0 or None
@@ -514,7 +514,7 @@ def swaggerize_request(request, op, **kwargs):
 
     :type request: :class:`pyramid.request.Request`
     :type op: :class:`bravado_core.operation.Operation`
-    :type validatation_context: context manager
+    :type validation_context: context manager
     """
     validation_context = kwargs['validation_context']
     with validation_context(request):
@@ -578,9 +578,3 @@ def get_swagger_versions(settings):
             raise ValueError('Swagger version {0} is not supported.'
                              .format(swagger_version))
     return swagger_versions
-
-
-def register_user_formatters(settings):
-    formats = settings.get('pyramid_swagger.user_formats', [])
-    for user_format in formats:
-        bravado_core.formatter.register_format(user_format)

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     packages=find_packages(exclude=["contrib", "docs", "tests*"]),
     include_package_data=True,
     install_requires=[
-        'bravado-core >= 2.4.0',
+        'bravado-core >= 3.0.2',
         'jsonschema',
         'pyramid<1.6.0a',
         'simplejson',

--- a/tests/acceptance/format_test.py
+++ b/tests/acceptance/format_test.py
@@ -28,21 +28,21 @@ def user_format():
 
 
 @pytest.fixture
-def test_app_with_base64(settings, user_format):
-    """Fixture for setting up a Swagger 2.0 version of the test test_app."""
+def testapp_with_base64(settings, user_format):
+    """Fixture for setting up a Swagger 2.0 version of the test testapp."""
     settings['pyramid_swagger.swagger_versions'] = ['2.0']
     settings['pyramid_swagger.user_formats'] = [user_format]
     return TestApp(main({}, **settings))
 
 
-def test_user_format_happy_case(test_app_with_base64):
-    response = test_app_with_base64.get('/sample/path_arg1/resource',
-                                        params={'required_arg': 'MQ=='},)
+def test_user_format_happy_case(testapp_with_base64):
+    response = testapp_with_base64.get('/sample/path_arg1/resource',
+                                       params={'required_arg': 'MQ=='},)
     assert response.status_code == 200
 
 
-def test_user_format_failure_case(test_app_with_base64):
+def test_user_format_failure_case(testapp_with_base64):
     # 'MQ' is not a valid base64 encoded string.
     with pytest.raises(Exception):
-        test_app_with_base64.get('/sample/path_arg1/resource',
-                                 params={'required_arg': 'MQ'},)
+        testapp_with_base64.get('/sample/path_arg1/resource',
+                                params={'required_arg': 'MQ'},)

--- a/tests/ingest_test.py
+++ b/tests/ingest_test.py
@@ -16,6 +16,7 @@ from pyramid_swagger.ingest import ingest_resources
 from pyramid_swagger.ingest import ApiDeclarationNotFoundError
 from pyramid_swagger.ingest import ResourceListingGenerationError
 from pyramid_swagger.ingest import ResourceListingNotFoundError
+from pyramid_swagger.tween import SwaggerFormat
 
 
 def test_proper_error_on_missing_resource_listing():
@@ -118,17 +119,20 @@ def test_create_bravado_core_config_with_defaults():
 
 
 def test_create_bravado_core_config_non_empty():
+    some_format = mock.Mock(spec=SwaggerFormat)
     pyramid_swagger_config = {
         'pyramid_swagger.enable_request_validation': True,
         'pyramid_swagger.enable_response_validation': False,
         'pyramid_swagger.enable_swagger_spec_validation': True,
         'pyramid_swagger.use_models': True,
+        'pyramid_swagger.user_formats': [some_format],
     }
     expected_bravado_core_config = {
         'validate_requests': True,
         'validate_responses': False,
         'validate_swagger_spec': True,
-        'use_models': True
+        'use_models': True,
+        'formats': [some_format]
     }
     bravado_core_config = create_bravado_core_config(pyramid_swagger_config)
     assert expected_bravado_core_config == bravado_core_config

--- a/tests/tween_test.py
+++ b/tests/tween_test.py
@@ -20,14 +20,12 @@ from pyramid_swagger.model import PathNotMatchedError
 from pyramid_swagger.tween import DEFAULT_EXCLUDED_PATHS, get_op_for_request, \
     validation_error
 from pyramid_swagger.tween import PyramidSwaggerRequest
-from pyramid_swagger.tween import SwaggerFormat
 from pyramid_swagger.tween import get_exclude_paths
 from pyramid_swagger.tween import get_swagger_objects
 from pyramid_swagger.tween import get_swagger_versions
 from pyramid_swagger.tween import handle_request
 from pyramid_swagger.tween import noop_context
 from pyramid_swagger.tween import prepare_body
-from pyramid_swagger.tween import register_user_formatters
 from pyramid_swagger.tween import Settings
 from pyramid_swagger.tween import should_exclude_path
 from pyramid_swagger.tween import should_exclude_route
@@ -249,14 +247,6 @@ def test_get_swagger_versions_unsupported():
     with pytest.raises(ValueError) as excinfo:
         get_swagger_versions(settings)
     assert 'Swagger version 10.0 is not supported' in str(excinfo.value)
-
-
-def test_user_defined_formats_get_registered():
-    foo_formatter = Mock(spec=SwaggerFormat)
-    settings = {'pyramid_swagger.user_formats': [foo_formatter]}
-    with mock.patch('bravado_core.formatter.register_format') as m:
-        register_user_formatters(settings)
-        m.assert_called_once_with(foo_formatter)
 
 
 def test_validaton_error_decorator_transforms_SwaggerMappingError():


### PR DESCRIPTION
This results in no changes to the pyramid-swagger public interface.

To see changes since 2.4.0: http://bravado-core.readthedocs.org/en/latest/changelog.html#id1

