### PR TITLE
Fix issue with pyramid route_prefix

### DIFF
--- a/pyramid_swagger/tween.py
+++ b/pyramid_swagger/tween.py
@@ -552,7 +552,10 @@ def get_op_for_request(request, route_info, spec):
     # pyramid.urldispath.Route
     route = route_info['route']
     if hasattr(route, 'path'):
-        op = spec.get_op_for_request(request.method, route.path)
+        route_path = route.path
+        if route_path[0] != '/':
+            route_path = '/' + route_path
+        op = spec.get_op_for_request(request.method, route_path)
         if op is not None:
             return op
     raise PathNotMatchedError(

--- a/tests/acceptance/app/__init__.py
+++ b/tests/acceptance/app/__init__.py
@@ -51,8 +51,12 @@ def main(global_config, **settings):
     config.add_route('post_with_form_params', '/post_with_form_params')
     config.add_route('post_with_file_upload', '/post_with_file_upload')
     config.add_route('sample_post', '/sample')
-    config.add_route('sample_header', '/sample/header')
+    config.include(include_samples, route_prefix='/sample')
     config.add_route('throw_400', '/throw_400')
 
     config.scan()
     return config.make_wsgi_app()
+
+
+def include_samples(config):
+    config.add_route('sample_header', '/header')


### PR DESCRIPTION
Pyramid seems to remove the preceding '/' from the route_prefix. This ensures that the '/' exists, and adds a test proving that it's broken/fixed.