### PR TITLE
Add yaml support

### DIFF
--- a/pyramid_swagger/__init__.py
+++ b/pyramid_swagger/__init__.py
@@ -4,7 +4,10 @@ Import this module to add the validation tween to your pyramid app.
 """
 import pyramid
 
-from .api import register_api_doc_endpoints, build_swagger_20_swagger_dot_json
+from .api import (
+    register_api_doc_endpoints,
+    build_swagger_20_swagger_schema_views,
+)
 from .ingest import get_swagger_schema
 from .ingest import get_swagger_spec
 from .tween import get_swagger_versions, SWAGGER_12, SWAGGER_20
@@ -16,6 +19,11 @@ def includeme(config):
     """
     settings = config.registry.settings
     swagger_versions = get_swagger_versions(settings)
+
+    # for rendering /swagger.yaml
+    config.add_renderer(
+        'yaml', 'pyramid_swagger.api.YamlRendererFactory',
+    )
 
     # Add the SwaggerSchema to settings to make it available to the validation
     # tween and `register_api_doc_endpoints`
@@ -45,5 +53,5 @@ def includeme(config):
         if SWAGGER_20 in swagger_versions:
             register_api_doc_endpoints(
                 config,
-                [build_swagger_20_swagger_dot_json(config)],
+                build_swagger_20_swagger_schema_views(config),
                 base_path='')

--- a/pyramid_swagger/api.py
+++ b/pyramid_swagger/api.py
@@ -98,9 +98,10 @@ def build_swagger_12_api_declaration_view(api_declaration_json):
 
 
 def resolve_ref(spec, url):
-    abs_path, spec_dict = spec.resolver.resolve(url)
-    spec_dict = copy.deepcopy(spec_dict)
-    return resolve_refs(spec, spec_dict)
+    with spec.resolver.resolving(url):
+        abs_path, spec_dict = spec.resolver.resolve(url)
+        spec_dict = copy.deepcopy(spec_dict)
+        return resolve_refs(spec, spec_dict)
 
 
 def resolve_refs(spec, val):
@@ -108,7 +109,8 @@ def resolve_refs(spec, val):
         new_dict = {}
         for key, subval in val.items():
             if key == '$ref':
-                new_dict[key] = resolve_ref(spec, subval)
+                # assume $ref is the only key in the dict
+                return resolve_ref(spec, subval)
             elif key == 'x-scope':
                 pass   # ignore this; implementation details
             else:

--- a/pyramid_swagger/api.py
+++ b/pyramid_swagger/api.py
@@ -111,8 +111,6 @@ def resolve_refs(spec, val):
             if key == '$ref':
                 # assume $ref is the only key in the dict
                 return resolve_ref(spec, subval)
-            elif key == 'x-scope':
-                pass   # ignore this; implementation details
             else:
                 new_dict[key] = resolve_refs(spec, subval)
         return new_dict

--- a/pyramid_swagger/api.py
+++ b/pyramid_swagger/api.py
@@ -2,7 +2,9 @@
 """
 Module for automatically serving /api-docs* via Pyramid.
 """
+import copy
 import simplejson
+import yaml
 
 from pyramid_swagger.model import PyramidEndpoint
 
@@ -95,14 +97,62 @@ def build_swagger_12_api_declaration_view(api_declaration_json):
     return view_for_api_declaration
 
 
-def build_swagger_20_swagger_dot_json(config):
+def resolve_ref(spec, url):
+    abs_path, spec_dict = spec.resolver.resolve(url)
+    spec_dict = copy.deepcopy(spec_dict)
+    return resolve_refs(spec, spec_dict)
 
-    def view_for_swagger_dot_json(request):
-        spec = config.registry.settings['pyramid_swagger.schema20']
-        return spec.spec_dict
 
-    return PyramidEndpoint(
+def resolve_refs(spec, val):
+    if isinstance(val, dict):
+        new_dict = {}
+        for key, subval in val.items():
+            if key == '$ref':
+                new_dict[key] = resolve_ref(spec, subval)
+            elif key == 'x-scope':
+                pass   # ignore this; implementation details
+            else:
+                new_dict[key] = resolve_refs(spec, subval)
+        return new_dict
+
+    if isinstance(val, list):
+        for index, subval in enumerate(val):
+            val[index] = resolve_refs(spec, subval)
+
+    return val
+
+
+class YamlRendererFactory(object):
+    def __init__(self, info):
+        pass
+
+    def __call__(self, value, system):
+        response = system['request'].response
+        response.headers['Content-Type'] = 'application/x-yaml; charset=UTF-8'
+        return yaml.dump(value).encode('utf-8')
+
+
+def build_swagger_20_swagger_schema_views(config):
+    def view_for_swagger_schema(request):
+        settings = config.registry.settings
+        resolved_dict = settings.get('pyramid_swagger.schema20_resolved')
+        if not resolved_dict:
+            spec = settings['pyramid_swagger.schema20']
+            spec_copy = copy.deepcopy(spec.spec_dict)
+            resolved_dict = resolve_refs(spec, spec_copy)
+            settings['pyramid_swagger.schema20_resolved'] = resolved_dict
+        return resolved_dict
+
+    yield PyramidEndpoint(
         path='/swagger.json',
-        route_name='pyramid_swagger.swagger20.api_docs',
-        view=view_for_swagger_dot_json,
-        renderer='json')
+        route_name='pyramid_swagger.swagger20.api_docs.json',
+        view=view_for_swagger_schema,
+        renderer='json',
+    )
+
+    yield PyramidEndpoint(
+        path='/swagger.yaml',
+        route_name='pyramid_swagger.swagger20.api_docs.yaml',
+        view=view_for_swagger_schema,
+        renderer='yaml',
+    )

--- a/pyramid_swagger/api.py
+++ b/pyramid_swagger/api.py
@@ -138,7 +138,7 @@ def build_swagger_20_swagger_schema_views(config):
         resolved_dict = settings.get('pyramid_swagger.schema20_resolved')
         if not resolved_dict:
             spec = settings['pyramid_swagger.schema20']
-            spec_copy = copy.deepcopy(spec.spec_dict)
+            spec_copy = copy.deepcopy(spec.client_spec_dict)
             resolved_dict = resolve_refs(spec, spec_copy)
             settings['pyramid_swagger.schema20_resolved'] = resolved_dict
         return resolved_dict

--- a/pyramid_swagger/ingest.py
+++ b/pyramid_swagger/ingest.py
@@ -3,10 +3,9 @@ from __future__ import unicode_literals
 
 import glob
 import os.path
-import yaml
 
 import simplejson
-from bravado_core.spec import Spec
+from bravado_core.spec import Spec, build_http_handlers
 from six.moves.urllib import parse as urlparse
 
 from .api import build_swagger_12_endpoints
@@ -174,16 +173,9 @@ def get_swagger_spec(settings):
     schema_path = os.path.join(schema_dir, schema_filename)
     schema_url = urlparse.urljoin('file:', os.path.abspath(schema_path))
 
-    fname, ext = os.path.splitext(schema_filename)
-    ext = ext.lower()
-    if ext == '.json':
-        with open(schema_path, 'r') as f:
-            spec_dict = simplejson.loads(f.read())
-    elif ext in ('.yaml', '.yml'):
-        with open(schema_path, 'r') as f:
-            spec_dict = yaml.load(f)
-    else:
-        raise Exception("Unknown extension: %s" % ext)
+    handlers = build_http_handlers(None)  # don't need http_client for file:
+    file_handler = handlers['file']
+    spec_dict = file_handler(schema_url)
 
     return Spec.from_dict(
         spec_dict,

--- a/pyramid_swagger/ingest.py
+++ b/pyramid_swagger/ingest.py
@@ -169,7 +169,8 @@ def get_swagger_spec(settings):
     :rtype: :class:`bravado_core.spec.Spec`
     """
     schema_dir = settings.get('pyramid_swagger.schema_directory', 'api_docs/')
-    schema_filename = settings.get('pyramid_swagger.schema_file', 'swagger.json')
+    schema_filename = settings.get('pyramid_swagger.schema_file',
+                                   'swagger.json')
     schema_path = os.path.join(schema_dir, schema_filename)
     schema_url = urlparse.urljoin('file:', os.path.abspath(schema_path))
 

--- a/pyramid_swagger/ingest.py
+++ b/pyramid_swagger/ingest.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 import glob
 import os.path
+import yaml
 
 import simplejson
 from bravado_core.spec import Spec
@@ -168,11 +169,20 @@ def get_swagger_spec(settings):
     :rtype: :class:`bravado_core.spec.Spec`
     """
     schema_dir = settings.get('pyramid_swagger.schema_directory', 'api_docs/')
-    schema_path = os.path.join(schema_dir, 'swagger.json')
+    schema_filename = settings.get('pyramid_swagger.schema_file', 'swagger.json')
+    schema_path = os.path.join(schema_dir, schema_filename)
     schema_url = urlparse.urljoin('file:', os.path.abspath(schema_path))
 
-    with open(schema_path, 'r') as f:
-        spec_dict = simplejson.loads(f.read())
+    fname, ext = os.path.splitext(schema_filename)
+    ext = ext.lower()
+    if ext == '.json':
+        with open(schema_path, 'r') as f:
+            spec_dict = simplejson.loads(f.read())
+    elif ext in ('.yaml', '.yml'):
+        with open(schema_path, 'r') as f:
+            spec_dict = yaml.load(f)
+    else:
+        raise Exception("Unknown extension: %s" % ext)
 
     return Spec.from_dict(
         spec_dict,

--- a/pyramid_swagger/tween.py
+++ b/pyramid_swagger/tween.py
@@ -33,7 +33,7 @@ SUPPORTED_SWAGGER_VERSIONS = [SWAGGER_12, SWAGGER_20]
 DEFAULT_EXCLUDED_PATHS = [
     r'^/static/?',
     r'^/api-docs/?',
-    r'^/swagger.json',
+    r'^/swagger.(json|yaml)',
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     packages=find_packages(exclude=["contrib", "docs", "tests*"]),
     include_package_data=True,
     install_requires=[
-        'bravado-core >= 3.0.2',
+        'bravado-core >= 4.1.0',
         'jsonschema',
         'pyramid',
         'simplejson',

--- a/setup.py
+++ b/setup.py
@@ -43,5 +43,6 @@ setup(
         'jsonschema',
         'pyramid',
         'simplejson',
+        'pyyaml',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,5 @@ setup(
         'jsonschema',
         'pyramid',
         'simplejson',
-        'pyyaml',
     ],
 )

--- a/tests/acceptance/invalid_file_test.py
+++ b/tests/acceptance/invalid_file_test.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+import base64
+
+import pytest
+from webtest import TestApp
+
+from .app import main
+from pyramid_swagger.tween import SwaggerFormat
+
+
+@pytest.fixture
+def settings():
+    dir_path = 'tests/sample_schemas/'
+    return {
+        'pyramid_swagger.schema_file': 'swagger.txt',
+        'pyramid_swagger.schema_directory': dir_path,
+        'pyramid_swagger.enable_request_validation': True,
+        'pyramid_swagger.enable_swagger_spec_validation': True,
+    }
+
+
+@pytest.fixture
+def yaml_app():
+    return SwaggerFormat(format='base64',
+                         to_wire=base64.b64encode,
+                         to_python=base64.b64decode,
+                         validate=base64.b64decode,
+                         description='base64')
+
+
+def test_invalid_file_extension(settings, yaml_app):
+    """Fixture for setting up a Swagger 2.0 version of the test testapp."""
+    settings['pyramid_swagger.swagger_versions'] = ['2.0']
+    settings['pyramid_swagger.user_formats'] = [yaml_app]
+
+    with pytest.raises(Exception):
+        TestApp(main({}, **settings))

--- a/tests/acceptance/response20_test.py
+++ b/tests/acceptance/response20_test.py
@@ -157,7 +157,7 @@ def test_500_when_response_arg_is_wrong_type():
             response=response,
             path_pattern='/sample/{path_arg}/resource')
 
-    assert "1.0 is not of type 'string'" in str(excinfo.value)
+    assert "1.0 is not of type " in str(excinfo.value)
 
 
 def test_500_for_bad_validated_array_response():
@@ -175,7 +175,7 @@ def test_500_for_bad_validated_array_response():
             response=response,
             path_pattern='/sample_array_response')
 
-    assert "'bad_enum_value' is not one of ['good_enum_value']" in \
+    assert "'bad_enum_value' is not one of " in \
            str(excinfo.value)
 
 

--- a/tests/acceptance/response_test.py
+++ b/tests/acceptance/response_test.py
@@ -169,7 +169,7 @@ def test_500_when_response_arg_is_wrong_type():
     )
     with pytest.raises(ResponseValidationError) as excinfo:
         _validate_against_tween(request, response=response)
-    assert "1.0 is not of type 'string'" in str(excinfo.value)
+    assert "1.0 is not of type " in str(excinfo.value)
 
 
 def test_500_for_bad_validated_array_response():
@@ -183,7 +183,7 @@ def test_500_for_bad_validated_array_response():
     )
     with pytest.raises(ResponseValidationError) as excinfo:
         _validate_against_tween(request, response=response)
-    assert "is not one of ['good_enum_value']" in str(excinfo.value)
+    assert "is not one of [" in str(excinfo.value)
 
 
 def test_200_for_good_validated_array_response():

--- a/tests/acceptance/yaml_test.py
+++ b/tests/acceptance/yaml_test.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+import base64
+
+import pytest
+from webtest import TestApp
+
+from .app import main
+from pyramid_swagger.tween import SwaggerFormat
+
+
+@pytest.fixture
+def settings():
+    dir_path = 'tests/sample_schemas/yaml_app/'
+    return {
+        'pyramid_swagger.schema_file': 'swagger.yaml',
+        'pyramid_swagger.schema_directory': dir_path,
+        'pyramid_swagger.enable_request_validation': True,
+        'pyramid_swagger.enable_swagger_spec_validation': True,
+    }
+
+
+@pytest.fixture
+def yaml_app():
+    return SwaggerFormat(format='base64',
+                         to_wire=base64.b64encode,
+                         to_python=base64.b64decode,
+                         validate=base64.b64decode,
+                         description='base64')
+
+
+@pytest.fixture
+def testapp_with_base64(settings, yaml_app):
+    """Fixture for setting up a Swagger 2.0 version of the test testapp."""
+    settings['pyramid_swagger.swagger_versions'] = ['2.0']
+    settings['pyramid_swagger.user_formats'] = [yaml_app]
+    return TestApp(main({}, **settings))
+
+
+def test_user_format_happy_case(testapp_with_base64):
+    response = testapp_with_base64.get('/sample/path_arg1/resource',
+                                       params={'required_arg': 'MQ=='},)
+    assert response.status_code == 200
+
+
+def test_user_format_failure_case(testapp_with_base64):
+    # 'MQ' is not a valid base64 encoded string.
+    with pytest.raises(Exception):
+        testapp_with_base64.get('/sample/path_arg1/resource',
+                                params={'required_arg': 'MQ'},)

--- a/tests/acceptance/yaml_test.py
+++ b/tests/acceptance/yaml_test.py
@@ -47,3 +47,81 @@ def test_user_format_failure_case(testapp_with_base64):
     with pytest.raises(Exception):
         testapp_with_base64.get('/sample/path_arg1/resource',
                                 params={'required_arg': 'MQ'},)
+
+
+def test_swagger_json_api_doc_route(testapp_with_base64):
+    expected_schema = {
+        'host': 'localhost:9999',
+        'info': {
+            'title': 'Title was not specified',
+            'version': '0.1',
+        },
+        'produces': ['application/json'],
+        'schemes': ['http'],
+        'swagger': '2.0',
+        'paths': {
+            '/sample/{path_arg}/resource': {
+                'get': {
+                    'description': '',
+                    'operationId': 'standard',
+                    'parameters': [
+                        {
+                            'enum': ['path_arg1', 'path_arg2'],
+                            'in': 'path',
+                            'name': 'path_arg',
+                            'required': True,
+                            'type': 'string',
+                        }, {
+                            'format': 'base64',
+                            'in': 'query',
+                            'name': 'required_arg',
+                            'required': True,
+                            'type': 'string',
+                        }, {
+                            'in': 'query',
+                            'name': 'optional_arg',
+                            'required': False,
+                            'type': 'string',
+                        },
+                    ],
+                    'responses': {
+                        '200': {
+                            'description': 'Return a standard_response',
+                            'schema': {
+                                '$ref': {
+                                    'additionalProperties': False,
+                                    'properties': {
+                                        'logging_info': {'type': 'object'},
+                                        'raw_response': {'type': 'string'},
+                                    },
+                                    'required': [
+                                        'raw_response',
+                                        'logging_info',
+                                    ],
+                                    'type': 'object',
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    }
+
+    response = testapp_with_base64.get(
+        '/swagger.json',
+    )
+    assert response.status_code == 200
+    assert response.headers['content-type'] == ('application/json; '
+                                                'charset=UTF-8')
+    import json
+    assert json.loads(response.body.decode("utf-8")) == expected_schema
+
+    response = testapp_with_base64.get(
+        '/swagger.yaml',
+    )
+    assert response.status_code == 200
+    assert response.headers['content-type'] == ('application/x-yaml; '
+                                                'charset=UTF-8')
+    import yaml
+    assert yaml.load(response.body) == expected_schema

--- a/tests/acceptance/yaml_test.py
+++ b/tests/acceptance/yaml_test.py
@@ -88,18 +88,57 @@ def test_swagger_json_api_doc_route(testapp_with_base64):
                         '200': {
                             'description': 'Return a standard_response',
                             'schema': {
-                                '$ref': {
-                                    'additionalProperties': False,
-                                    'properties': {
-                                        'logging_info': {'type': 'object'},
-                                        'raw_response': {'type': 'string'},
-                                    },
-                                    'required': [
-                                        'raw_response',
-                                        'logging_info',
-                                    ],
-                                    'type': 'object',
+                                'additionalProperties': False,
+                                'properties': {
+                                    'logging_info': {'type': 'object'},
+                                    'raw_response': {'type': 'string'},
                                 },
+                                'required': [
+                                    'raw_response',
+                                    'logging_info',
+                                ],
+                                'type': 'object',
+                            },
+                        },
+                    },
+                },
+                'post': {
+                    'parameters': [
+                        {
+                            'in': 'path',
+                            'name': 'path_arg',
+                            'required': True,
+                            'type': 'string',
+                        }, {
+                            'in': 'body',
+                            'name': 'request',
+                            'required': True,
+                            'schema': {
+                                'additionalProperties': False,
+                                'properties': {
+                                    'bar': {'type': 'string'},
+                                    'foo': {'type': 'string'},
+                                },
+                                'required': ['foo'],
+                                'type': 'object',
+                            },
+                        },
+                    ],
+                    'responses': {
+                        'default': {
+                            'description': 'test '
+                            'response',
+                            'schema': {
+                                'additionalProperties': False,
+                                'properties': {
+                                    'logging_info': {'type': 'object'},
+                                    'raw_response': {'type': 'string'},
+                                },
+                                'required': [
+                                    'raw_response',
+                                    'logging_info'
+                                ],
+                                'type': 'object',
                             },
                         },
                     },

--- a/tests/ingest_test.py
+++ b/tests/ingest_test.py
@@ -36,12 +36,13 @@ def test_proper_error_on_missing_api_declaration():
     assert 'fake/sample_resource.json' in str(exc)
 
 
-@mock.patch('six.moves.builtins.open', return_value=mock.MagicMock())
+@mock.patch('pyramid_swagger.ingest.build_http_handlers',
+            return_value={'file': mock.Mock()})
 @mock.patch('os.path.abspath', return_value='/bar/foo/swagger.json')
-@mock.patch('simplejson.loads', return_value=mock.Mock(spec=dict))
 @mock.patch('pyramid_swagger.ingest.Spec.from_dict')
-def test_get_swagger_spec_passes_absolute_url(mock_spec, mock_simple,
-                                              mock_abs, mock_open):
+def test_get_swagger_spec_passes_absolute_url(
+    mock_spec, mock_abs, mock_http_handlers,
+):
     get_swagger_spec({'pyramid_swagger.schema_directory': 'foo/'})
     mock_abs.assert_called_once_with('foo/swagger.json')
     expected_url = "file:///bar/foo/swagger.json"

--- a/tests/sample_schemas/yaml_app/defs.yaml
+++ b/tests/sample_schemas/yaml_app/defs.yaml
@@ -28,3 +28,21 @@ definitions:
         type: "string"
         enum:
           - "good_enum_value"
+
+operations:
+  post:
+    parameters:
+      - name: path_arg
+        in: path
+        type: string
+        required: true
+      - name: request
+        in: body
+        required: true
+        schema:
+          $ref: "#/definitions/body_model"
+    responses:
+      default:
+        description: test response
+        schema:
+          $ref: "#/definitions/standard_response"

--- a/tests/sample_schemas/yaml_app/defs.yaml
+++ b/tests/sample_schemas/yaml_app/defs.yaml
@@ -1,0 +1,30 @@
+definitions:
+  standard_response:
+    type: "object"
+    required:
+      - "raw_response"
+      - "logging_info"
+    additionalProperties: false
+    properties:
+      raw_response:
+        type: "string"
+      logging_info:
+        type: "object"
+  body_model:
+    type: "object"
+    required:
+      - "foo"
+    additionalProperties: false
+    properties:
+      foo:
+        type: "string"
+      bar:
+        type: "string"
+  array_content_model:
+    required:
+      - "enum_value"
+    properties:
+      enum_value:
+        type: "string"
+        enum:
+          - "good_enum_value"

--- a/tests/sample_schemas/yaml_app/swagger.yaml
+++ b/tests/sample_schemas/yaml_app/swagger.yaml
@@ -35,3 +35,5 @@ paths:
           name: "optional_arg"
           required: false
           type: "string"
+    post:
+      $ref: defs.yaml#/operations/post

--- a/tests/sample_schemas/yaml_app/swagger.yaml
+++ b/tests/sample_schemas/yaml_app/swagger.yaml
@@ -1,0 +1,96 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Title was not specified",
+    "version": "0.1"
+  },
+  "produces": ["application/json"],
+  "paths": {
+    "/sample/{path_arg}/resource": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Return a standard_response",
+            "schema": {
+              "$ref": "#/definitions/standard_response"
+            }
+          }
+        },
+        "description": "",
+        "operationId": "standard",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "path_arg",
+            "required": true,
+            "type": "string",
+            "enum": ["path_arg1", "path_arg2"]
+          },
+          {
+            "in": "query",
+            "name": "required_arg",
+            "required": true,
+            "type": "string",
+            "format": "base64"
+          },
+          {
+            "in": "query",
+            "name": "optional_arg",
+            "required": false,
+            "type": "string"
+          }
+        ]
+      }
+    }
+  },
+  "host": "localhost:9999",
+  "schemes": [
+    "http"
+  ],
+  "definitions": {
+    "standard_response": {
+      "type": "object",
+      "required": [
+        "raw_response",
+        "logging_info"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "raw_response": {
+          "type": "string"
+        },
+        "logging_info": {
+          "type": "object"
+        }
+      }
+    },
+    "body_model": {
+      "type": "object",
+      "required": [
+        "foo"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "foo": {
+          "type": "string"
+        },
+        "bar": {
+          "type": "string"
+        }
+      }
+    },
+    "array_content_model": {
+      "required": [
+        "enum_value"
+      ],
+      "properties": {
+        "enum_value": {
+          "type": "string",
+          "enum": [
+            "good_enum_value"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/tests/sample_schemas/yaml_app/swagger.yaml
+++ b/tests/sample_schemas/yaml_app/swagger.yaml
@@ -1,96 +1,37 @@
-{
-  "swagger": "2.0",
-  "info": {
-    "title": "Title was not specified",
-    "version": "0.1"
-  },
-  "produces": ["application/json"],
-  "paths": {
-    "/sample/{path_arg}/resource": {
-      "get": {
-        "responses": {
-          "200": {
-            "description": "Return a standard_response",
-            "schema": {
-              "$ref": "#/definitions/standard_response"
-            }
-          }
-        },
-        "description": "",
-        "operationId": "standard",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "path_arg",
-            "required": true,
-            "type": "string",
-            "enum": ["path_arg1", "path_arg2"]
-          },
-          {
-            "in": "query",
-            "name": "required_arg",
-            "required": true,
-            "type": "string",
-            "format": "base64"
-          },
-          {
-            "in": "query",
-            "name": "optional_arg",
-            "required": false,
-            "type": "string"
-          }
-        ]
-      }
-    }
-  },
-  "host": "localhost:9999",
-  "schemes": [
-    "http"
-  ],
-  "definitions": {
-    "standard_response": {
-      "type": "object",
-      "required": [
-        "raw_response",
-        "logging_info"
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "raw_response": {
-          "type": "string"
-        },
-        "logging_info": {
-          "type": "object"
-        }
-      }
-    },
-    "body_model": {
-      "type": "object",
-      "required": [
-        "foo"
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "foo": {
-          "type": "string"
-        },
-        "bar": {
-          "type": "string"
-        }
-      }
-    },
-    "array_content_model": {
-      "required": [
-        "enum_value"
-      ],
-      "properties": {
-        "enum_value": {
-          "type": "string",
-          "enum": [
-            "good_enum_value"
-          ]
-        }
-      }
-    }
-  }
-}
+---
+swagger: "2.0"
+info:
+  title: "Title was not specified"
+  version: "0.1"
+host: "localhost:9999"
+schemes:
+  - "http"
+produces:
+  - "application/json"
+paths:
+  "/sample/{path_arg}/resource":
+    get:
+      responses:
+        "200":
+          description: "Return a standard_response"
+          schema:
+            "$ref": "defs.yaml#/definitions/standard_response"
+      description: ""
+      operationId: "standard"
+      parameters:
+        - in: "path"
+          name: "path_arg"
+          required: true
+          type: "string"
+          enum:
+            - "path_arg1"
+            - "path_arg2"
+        - in: "query"
+          name: "required_arg"
+          required: true
+          type: "string"
+          format: "base64"
+        - in: "query"
+          name: "optional_arg"
+          required: false
+          type: "string"


### PR DESCRIPTION
This was a bit more straightforward than I expected. After the changes in bravado-core, all I needed to do was reuse the bravado-core url handlers to open the file.

I also added a new configuration directive that allows you to define the file name (allowing you to use `swagger.yaml`). 

Two future ideas:
1.Ccombine `pyramid_swagger.schema_directory` and `pyramid_swagger.schema_file` to a single directive. The two fields seem redundant.
2. There are some issues with support for the `/api-docs/swagger.json` endpoint. It works on its own, but the yaml files that it links to are, well, yaml files, which prevents any swagger UIs from consuming them. I was considering finding a way to recombine the external yaml files into a single json file before returning it, but wanted to get people's feedback on that idea first.

Enjoy!

Edit: Solves #134 