### PR TITLE
Only run tests in the `test/` folder.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps =
     pyramid15: pyramid<=1.5.4
 
 commands =
-    coverage run --source=pyramid_swagger/ --omit=pyramid_swagger/__about__.py -m pytest --capture=no --strict {posargs}
+    coverage run --source=pyramid_swagger/ --omit=pyramid_swagger/__about__.py -m pytest --capture=no --strict tests/ {posargs}
     coverage report -m
 
 [testenv:pep8]

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps =
     pyramid15: pyramid<=1.5.4
 
 commands =
-    coverage run --source=pyramid_swagger/ --omit=pyramid_swagger/__about__.py -m pytest --capture=no --strict tests/ {posargs}
+    coverage run --source=pyramid_swagger/ --omit=pyramid_swagger/__about__.py -m pytest --capture=no --strict {posargs:tests/}
     coverage report -m
 
 [testenv:pep8]


### PR DESCRIPTION
This enables people to create their virtualenv in the same folder that 
the project is in, and still enable them to run `tox`. Without it, pytest
attempts to process all the files in your virtualenv.