### PR TITLE
Require bravado-core 4.2.0 so x-scope metadata is not sent to clients.

### DIFF
--- a/pyramid_swagger/api.py
+++ b/pyramid_swagger/api.py
@@ -99,7 +99,7 @@ def build_swagger_20_swagger_dot_json(config):
 
     def view_for_swagger_dot_json(request):
         spec = config.registry.settings['pyramid_swagger.schema20']
-        return spec.spec_dict
+        return spec.client_spec_dict
 
     return PyramidEndpoint(
         path='/swagger.json',

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     packages=find_packages(exclude=["contrib", "docs", "tests*"]),
     include_package_data=True,
     install_requires=[
-        'bravado-core >= 3.0.2',
+        'bravado-core >= 4.2.0',
         'jsonschema',
         'pyramid',
         'simplejson',


### PR DESCRIPTION
See https://github.com/Yelp/bravado-core/issues/78 for context.

This updates pyramid_swagger to serve up an ingestible Swagger Spec to clients with x-scope metadata removed.

Tested end to end with internal example_happyhour.