### PR TITLE
Response/Request property access improvements

### DIFF
--- a/pyramid_swagger/tween.py
+++ b/pyramid_swagger/tween.py
@@ -220,10 +220,6 @@ class PyramidSwaggerRequest(RequestLike):
         return self.route_info.get('match') or {}
 
     @property
-    def headers(self):
-        return self.request.headers
-
-    @property
     def form(self):
         """
         :rtype: dict
@@ -248,6 +244,12 @@ class PyramidSwaggerRequest(RequestLike):
     def json(self, **kwargs):
         return getattr(self.request, 'json_body', {})
 
+    def __getattr__(self, name):
+        try:
+            return getattr(self.request, name)
+        except:
+            return super(PyramidSwaggerRequest, self).__getattr__(name)
+
 
 class PyramidSwaggerResponse(OutgoingResponse):
     """Adapter for a :class:`pyramid.response.Response` which exposes response
@@ -269,6 +271,12 @@ class PyramidSwaggerResponse(OutgoingResponse):
 
     def json(self, **kwargs):
         return getattr(self.response, 'json_body', {})
+
+    def __getattr__(self, name):
+        try:
+            return getattr(self.response, name)
+        except:
+            return super(PyramidSwaggerResponse, self).__getattr__(name)
 
 
 def handle_request(request, validator_map, validation_context, **kwargs):

--- a/pyramid_swagger/tween.py
+++ b/pyramid_swagger/tween.py
@@ -247,7 +247,7 @@ class PyramidSwaggerRequest(RequestLike):
     def __getattr__(self, name):
         try:
             return getattr(self.request, name)
-        except:
+        except AttributeError:
             return super(PyramidSwaggerRequest, self).__getattr__(name)
 
 
@@ -275,7 +275,7 @@ class PyramidSwaggerResponse(OutgoingResponse):
     def __getattr__(self, name):
         try:
             return getattr(self.response, name)
-        except:
+        except AttributeError:
             return super(PyramidSwaggerResponse, self).__getattr__(name)
 
 

--- a/tests/tween_test.py
+++ b/tests/tween_test.py
@@ -341,14 +341,11 @@ def test_get_swagger12_objects_if_both_present_but_route_not_in_prefer20(
 
 
 def test_request_properties():
-    root_request = Request(
-        {},
-        body='{"myKey": 42}',
-        headers={"X-Some-Special-Header": "foobar"})
-    # this assert is intended to force the pyramid.request.Request to initialize its
-    # internal data structures correctly: without it, the json_body read will sometimes
-    # (but apparently not always) fail
-    assert '{"myKey": 42}' == root_request.body
+    root_request = Request({}, headers={"X-Some-Special-Header": "foobar"})
+    # this is a slightly baroque mechanism to make sure that the request is
+    # internally consistent for all test environments
+    root_request.body = '{"myKey": 42}'.encode()
+    assert '{"myKey": 42}' == root_request.text
     request = PyramidSwaggerRequest(root_request, {})
     assert {"myKey": 42} == request.body
     assert "foobar" == request.headers["X-Some-Special-Header"]

--- a/tests/tween_test.py
+++ b/tests/tween_test.py
@@ -357,10 +357,19 @@ def test_response_properties():
         body='{"myKey": 42}'
     )
     # these must be set for the "text" attribute of webob.Response to be
-    # readable, and setting them in the constructor appears ineffective:
+    # readable, and setting them in the constructor gets into a conflict
+    # with the custom header argument
     root_response.content_type = "application/json"
     root_response.charset = 'utf8'
     response = PyramidSwaggerResponse(root_response)
     assert '{"myKey": 42}' == response.text
     assert "foobar" == response.headers["X-Some-Special-Header"]
-    assert "utf8" == response.charset
+    assert 'application/json' == response.content_type
+
+
+def test_empty_response_properties():
+    root_response = Response(headers={"X-Some-Special-Header": "foobar"})
+    response = PyramidSwaggerResponse(root_response)
+    assert response.text is None
+    assert "foobar" == response.headers["X-Some-Special-Header"]
+    assert response.content_type is None

--- a/tests/tween_test.py
+++ b/tests/tween_test.py
@@ -345,6 +345,10 @@ def test_request_properties():
         {},
         body='{"myKey": 42}',
         headers={"X-Some-Special-Header": "foobar"})
+    # this assert is intended to force the pyramid.request.Request to initialize its
+    # internal data structures correctly: without it, the json_body read will sometimes
+    # (but apparently not always) fail
+    assert '{"myKey": 42}' == root_request.body
     request = PyramidSwaggerRequest(root_request, {})
     assert {"myKey": 42} == request.body
     assert "foobar" == request.headers["X-Some-Special-Header"]


### PR DESCRIPTION
This attempts to resolve an issue I encountered using a swagger spec that included header information in the response:

    "headers": {
        "Last-Modified": {
            "description": "The last date at which the results of your query would have changed",
            "type": "string",
            "format": "date-time"
        }
    }

When a request is made for this path with response validation turned on, it results in an exception in bravado_core:

    NotImplementedError: This OutgoingResponse type <class 'pyramid_swagger.tween.PyramidSwaggerResponse'> forgot to implement an attr for `headers`

This patch makes the PyramidSwaggerRequest and PyramidSwaggerResponse classes delegate all unknown attribute requests to the wrapped pyramid.Request and pyramid.Response objects, rather than just adding a `headers` property method to PyramidSwagerResponse, so that any future additional attribute reads from bravado_core can also be satisfied without further changes in this project.