### PR TITLE
Repackage model references to return a single file for the `/swagger.json` api

### DIFF
--- a/pyramid_swagger/api.py
+++ b/pyramid_swagger/api.py
@@ -3,6 +3,7 @@
 Module for automatically serving /api-docs* via Pyramid.
 """
 import copy
+import hashlib
 import simplejson
 import yaml
 
@@ -97,29 +98,58 @@ def build_swagger_12_api_declaration_view(api_declaration_json):
     return view_for_api_declaration
 
 
-def resolve_ref(spec, url):
-    with spec.resolver.resolving(url):
-        abs_path, spec_dict = spec.resolver.resolve(url)
-        spec_dict = copy.deepcopy(spec_dict)
-        return resolve_refs(spec, spec_dict)
+class RefResolver(object):
+    def __init__(self, spec):
+        self.spec = spec
+        self.origin_url = spec.origin_url
 
+        self.definitions = {}
+        self.defs_to_uuids = {}
 
-def resolve_refs(spec, val):
-    if isinstance(val, dict):
-        new_dict = {}
-        for key, subval in val.items():
-            if key == '$ref':
-                # assume $ref is the only key in the dict
-                return resolve_ref(spec, subval)
-            else:
-                new_dict[key] = resolve_refs(spec, subval)
-        return new_dict
+    def resolve(self):
+        spec_copy = copy.deepcopy(self.spec.client_spec_dict)
+        resolved_spec = self._resolve_refs(spec_copy)
+        if self.definitions:
+            resolved_spec['definitions'] = self.definitions
+        return resolved_spec
 
-    if isinstance(val, list):
-        for index, subval in enumerate(val):
-            val[index] = resolve_refs(spec, subval)
+    def _resolve_ref(self, url):
+        with self.spec.resolver.resolving(url):
+            abs_path, spec_dict = self.spec.resolver.resolve(url)
+            if abs_path.startswith(self.origin_url):
+                # if it's internal to the original, don't resolve
+                return {'$ref': url}
 
-    return val
+            key = self.defs_to_uuids.get(abs_path)
+            if not key:
+                m = hashlib.md5()
+                m.update(abs_path.encode('utf-8'))
+                key = m.hexdigest()
+                self.defs_to_uuids[abs_path] = key
+
+                spec_dict = copy.deepcopy(spec_dict)
+                resolved = self._resolve_refs(spec_dict)
+
+                self.definitions[key] = resolved
+
+            return {'$ref': '#/definitions/%s' % key}
+
+    def _resolve_refs(self, val):
+        if isinstance(val, dict):
+            new_dict = {}
+            for key, subval in val.items():
+                if key == '$ref':
+                    # assume $ref is the only key in the dict
+                    return self._resolve_ref(subval)
+                else:
+                    new_dict[key] = self._resolve_refs(subval)
+            return new_dict
+
+        if isinstance(val, list):
+            for index, subval in enumerate(val):
+                val[index] = self._resolve_refs(subval)
+
+        return val
 
 
 class YamlRendererFactory(object):
@@ -138,8 +168,8 @@ def build_swagger_20_swagger_schema_views(config):
         resolved_dict = settings.get('pyramid_swagger.schema20_resolved')
         if not resolved_dict:
             spec = settings['pyramid_swagger.schema20']
-            spec_copy = copy.deepcopy(spec.client_spec_dict)
-            resolved_dict = resolve_refs(spec, spec_copy)
+            resolver = RefResolver(spec)
+            resolved_dict = resolver.resolve()
             settings['pyramid_swagger.schema20_resolved'] = resolved_dict
         return resolved_dict
 

--- a/tests/acceptance/api_test.py
+++ b/tests/acceptance/api_test.py
@@ -77,3 +77,21 @@ def test_default_only_serves_up_swagger_20_schema(default_test_app):
     # swagger 1.2 schemas should 404
     for path in ('/api-docs', '/api-docs/sample', '/api-docs/other_sample'):
         default_test_app.get(path, status=404)
+
+
+def test_recursive_swagger_api_internal_refs():
+    recursive_test_app = TestApp(main({}, **{
+        'pyramid_swagger.schema_directory':
+            'tests/sample_schemas/recursive_app/internal/',
+    }))
+
+    recursive_test_app.get('/swagger.json', status=200)
+
+
+def test_recursive_swagger_api_external_refs():
+    recursive_test_app = TestApp(main({}, **{
+        'pyramid_swagger.schema_directory':
+            'tests/sample_schemas/recursive_app/external/',
+    }))
+
+    recursive_test_app.get('/swagger.json', status=200)

--- a/tests/acceptance/yaml_test.py
+++ b/tests/acceptance/yaml_test.py
@@ -56,6 +56,56 @@ def test_swagger_json_api_doc_route(testapp_with_base64):
             'title': 'Title was not specified',
             'version': '0.1',
         },
+        'definitions': {
+            '14bbccfbb528a176e560337905b4f9a5': {
+                'parameters': [
+                    {
+                        'in': 'path',
+                        'name': 'path_arg',
+                        'required': True,
+                        'type': 'string',
+                    }, {
+                        'in': 'body',
+                        'name': 'request',
+                        'required': True,
+                        'schema': {
+                            '$ref': '#/definitions/'
+                                    'd6de80d11d77b7f30906cd755c4bb99e',
+                        },
+                    },
+                ],
+                'responses': {
+                    'default': {
+                        'description': 'test response',
+                        'schema': {
+                            '$ref': '#/definitions/'
+                                    'b2bbc4901725f7ac48936b574761d65a'
+                        },
+                    },
+                },
+            },
+            'b2bbc4901725f7ac48936b574761d65a': {
+                'additionalProperties': False,
+                'properties': {
+                    'logging_info': {'type': 'object'},
+                    'raw_response': {'type': 'string'},
+                },
+                'required': [
+                    'raw_response',
+                    'logging_info',
+                ],
+                'type': 'object',
+            },
+            'd6de80d11d77b7f30906cd755c4bb99e': {
+                'additionalProperties': False,
+                'properties': {
+                    'bar': {'type': 'string'},
+                    'foo': {'type': 'string'},
+                },
+                'required': ['foo'],
+                'type': 'object',
+            },
+        },
         'produces': ['application/json'],
         'schemes': ['http'],
         'swagger': '2.0',
@@ -88,60 +138,14 @@ def test_swagger_json_api_doc_route(testapp_with_base64):
                         '200': {
                             'description': 'Return a standard_response',
                             'schema': {
-                                'additionalProperties': False,
-                                'properties': {
-                                    'logging_info': {'type': 'object'},
-                                    'raw_response': {'type': 'string'},
-                                },
-                                'required': [
-                                    'raw_response',
-                                    'logging_info',
-                                ],
-                                'type': 'object',
+                                '$ref': '#/definitions/'
+                                        'b2bbc4901725f7ac48936b574761d65a',
                             },
                         },
                     },
                 },
                 'post': {
-                    'parameters': [
-                        {
-                            'in': 'path',
-                            'name': 'path_arg',
-                            'required': True,
-                            'type': 'string',
-                        }, {
-                            'in': 'body',
-                            'name': 'request',
-                            'required': True,
-                            'schema': {
-                                'additionalProperties': False,
-                                'properties': {
-                                    'bar': {'type': 'string'},
-                                    'foo': {'type': 'string'},
-                                },
-                                'required': ['foo'],
-                                'type': 'object',
-                            },
-                        },
-                    ],
-                    'responses': {
-                        'default': {
-                            'description': 'test '
-                            'response',
-                            'schema': {
-                                'additionalProperties': False,
-                                'properties': {
-                                    'logging_info': {'type': 'object'},
-                                    'raw_response': {'type': 'string'},
-                                },
-                                'required': [
-                                    'raw_response',
-                                    'logging_info'
-                                ],
-                                'type': 'object',
-                            },
-                        },
-                    },
+                    '$ref': '#/definitions/14bbccfbb528a176e560337905b4f9a5',
                 },
             },
         },

--- a/tests/acceptance/yaml_test.py
+++ b/tests/acceptance/yaml_test.py
@@ -57,7 +57,7 @@ def test_swagger_json_api_doc_route(testapp_with_base64):
             'version': '0.1',
         },
         'definitions': {
-            '14bbccfbb528a176e560337905b4f9a5': {
+            'ab93f4a613e0c16483a66223dc431894': {
                 'parameters': [
                     {
                         'in': 'path',
@@ -70,7 +70,7 @@ def test_swagger_json_api_doc_route(testapp_with_base64):
                         'required': True,
                         'schema': {
                             '$ref': '#/definitions/'
-                                    'd6de80d11d77b7f30906cd755c4bb99e',
+                                    '8d88ccc5bec30137d053608584efb9e4',
                         },
                     },
                 ],
@@ -79,12 +79,12 @@ def test_swagger_json_api_doc_route(testapp_with_base64):
                         'description': 'test response',
                         'schema': {
                             '$ref': '#/definitions/'
-                                    'b2bbc4901725f7ac48936b574761d65a'
+                                    '0eb5f566c9c69b1b9b8a34d6bce04f7c'
                         },
                     },
                 },
             },
-            'b2bbc4901725f7ac48936b574761d65a': {
+            '0eb5f566c9c69b1b9b8a34d6bce04f7c': {
                 'additionalProperties': False,
                 'properties': {
                     'logging_info': {'type': 'object'},
@@ -96,7 +96,7 @@ def test_swagger_json_api_doc_route(testapp_with_base64):
                 ],
                 'type': 'object',
             },
-            'd6de80d11d77b7f30906cd755c4bb99e': {
+            '8d88ccc5bec30137d053608584efb9e4': {
                 'additionalProperties': False,
                 'properties': {
                     'bar': {'type': 'string'},
@@ -139,13 +139,13 @@ def test_swagger_json_api_doc_route(testapp_with_base64):
                             'description': 'Return a standard_response',
                             'schema': {
                                 '$ref': '#/definitions/'
-                                        'b2bbc4901725f7ac48936b574761d65a',
+                                        '0eb5f566c9c69b1b9b8a34d6bce04f7c',
                             },
                         },
                     },
                 },
                 'post': {
-                    '$ref': '#/definitions/14bbccfbb528a176e560337905b4f9a5',
+                    '$ref': '#/definitions/ab93f4a613e0c16483a66223dc431894',
                 },
             },
         },

--- a/tests/sample_schemas/recursive_app/external/external.json
+++ b/tests/sample_schemas/recursive_app/external/external.json
@@ -1,0 +1,18 @@
+{
+  "widget": {
+    "description": "A widget which may have multiple generations of child widgets",
+    "properties": {
+      "name": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 50
+      },
+      "children": {
+        "type": "array",
+        "items": {
+          "$ref":"#/widget"
+        }
+      }
+    }
+  }
+}

--- a/tests/sample_schemas/recursive_app/external/swagger.json
+++ b/tests/sample_schemas/recursive_app/external/swagger.json
@@ -1,0 +1,38 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Bug demo",
+    "description": "Recursive object definitions cause problems",
+    "version": "0.1.0"
+  },
+  "definitions": {
+    "widget": {
+      "$ref": "external.json#/widget"
+    }
+  },
+  "paths": {
+    "/resources/widget/{code}" : {
+      "parameters" : [
+        {
+          "name": "code",
+          "description": "The CODE value for a widget",
+          "in": "path",
+          "type": "string",
+          "required": true
+        }
+      ],
+      "get": {
+        "summary": "View a single widget",
+        "produces": ["application/json"],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description":"Widget local content (without parents or descendents)",
+            "schema": {"$ref":"external.json#/widget"}
+          },
+          "404": {"description": "The widget does not exist"}
+        }
+      }
+    }
+  }
+}

--- a/tests/sample_schemas/recursive_app/internal/swagger.json
+++ b/tests/sample_schemas/recursive_app/internal/swagger.json
@@ -1,0 +1,51 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Bug demo",
+    "description": "Recursive object definitions cause problems",
+    "version": "0.1.0"
+  },
+  "definitions": {
+    "widget": {
+      "description": "A widget which may have multiple generations of child widgets",
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 50
+        },
+        "children": {
+          "type": "array",
+          "items": {
+            "$ref":"#/definitions/widget"
+          }
+        }
+      }
+    }
+  },
+  "paths": {
+    "/resources/widget/{code}" : {
+      "parameters" : [
+        {
+          "name": "code",
+          "description": "The CODE value for a widget",
+          "in": "path",
+          "type": "string",
+          "required": true
+        }
+      ],
+      "get": {
+        "summary": "View a single widget",
+        "produces": ["application/json"],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description":"Widget local content (without parents or descendents)",
+            "schema": {"$ref":"#/definitions/widget"}
+          },
+          "404": {"description": "The widget does not exist"}
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
The previous solution expanded all models references. This turned out to be an
order of magnitude too lazy. This solution moves all external model references
to /definitions, making a single file with essentially the same structure as the
original files.

Fixes #160 