### PR TITLE
Serve full schemas, individually

### DIFF
--- a/pyramid_swagger/api.py
+++ b/pyramid_swagger/api.py
@@ -3,9 +3,13 @@
 Module for automatically serving /api-docs* via Pyramid.
 """
 import copy
+import os.path
 import simplejson
 import yaml
 
+
+from bravado_core.spec import strip_xscope
+from six.moves.urllib.parse import urlparse, urlunparse
 from pyramid_swagger.model import PyramidEndpoint
 
 
@@ -97,29 +101,135 @@ def build_swagger_12_api_declaration_view(api_declaration_json):
     return view_for_api_declaration
 
 
-def resolve_ref(spec, url):
-    with spec.resolver.resolving(url):
-        abs_path, spec_dict = spec.resolver.resolve(url)
-        spec_dict = copy.deepcopy(spec_dict)
-        return resolve_refs(spec, spec_dict)
+class NodeWalker(object):
+    def __init__(self):
+        pass
+
+    def walk(self, item, *args, **kwargs):
+        dupe = copy.deepcopy(item)
+        return self._walk(dupe, *args, **kwargs)
+
+    def _walk(self, item, *args, **kwargs):
+        if isinstance(item, list):
+            return self._walk_list(item, *args, **kwargs)
+
+        elif isinstance(item, dict):
+            return self._walk_dict(item, *args, **kwargs)
+
+        else:
+            return self._walk_item(item, *args, **kwargs)
+
+    def _walk_list(self, item, *args, **kwargs):
+        for index, subitem in enumerate(item):
+            item[index] = self._walk(subitem, *args, **kwargs)
+        return item
+
+    def _walk_dict(self, item, *args, **kwargs):
+        for key, value in item.items():
+            item[key] = self._walk_dict_item(key, value, *args, **kwargs)
+        return item
+
+    def _walk_dict_item(self, key, value, *args, **kwargs):
+        return self._walk(value, *args, **kwargs)
+
+    def _walk_item(self, value, *args, **kwargs):
+        return value
 
 
-def resolve_refs(spec, val):
-    if isinstance(val, dict):
-        new_dict = {}
-        for key, subval in val.items():
-            if key == '$ref':
-                # assume $ref is the only key in the dict
-                return resolve_ref(spec, subval)
-            else:
-                new_dict[key] = resolve_refs(spec, subval)
-        return new_dict
+class NodeWalkerForRefFiles(NodeWalker):
+    def walk(self, spec):
+        all_refs = []
 
-    if isinstance(val, list):
-        for index, subval in enumerate(val):
-            val[index] = resolve_refs(spec, subval)
+        spec_fname = spec.origin_url
+        if spec_fname.startswith('file://'):
+            spec_fname = spec_fname.replace('file://', '')
+        spec_dirname = os.path.dirname(spec_fname)
 
-    return val
+        parent = super(NodeWalkerForRefFiles, self)
+        parent.walk(spec.client_spec_dict, spec, spec_dirname, all_refs)
+
+        all_refs = [os.path.relpath(f, spec_dirname) for f in all_refs]
+        all_refs = set(all_refs)
+
+        core_dirname, core_fname = os.path.split(spec_fname)
+        all_refs.add(core_fname)
+
+        return all_refs
+
+    @staticmethod
+    def get_filename_without_schema(url):
+        parts = urlparse(url)
+
+        if parts.scheme or parts.netloc:
+            # only rewrite relative paths
+            return
+
+        if not parts.path:
+            # don't rewrite internal refs
+            return
+
+        if parts.path.startswith('/'):
+            # don't rewrite absolute refs
+            return
+
+        return parts.path
+
+    def _walk_dict_item(self, key, value, spec, dirname, all_refs):
+        if key != '$ref':
+            parent = super(NodeWalkerForRefFiles, self)
+            return parent._walk_dict_item(key, value, spec, dirname, all_refs)
+
+        # assume $ref is the only key in the dict
+        subval_fname = self.get_filename_without_schema(value)
+        if not subval_fname:
+            return value
+
+        full_fname = os.path.join(dirname, subval_fname)
+        norm_fname = os.path.normpath(full_fname)
+        all_refs.append(norm_fname)
+
+        with spec.resolver.resolving(value) as spec_dict:
+            dupe = copy.deepcopy(spec_dict)
+            self._walk(dupe, spec, os.path.dirname(norm_fname), all_refs)
+
+
+class NodeWalkerForCleaningRefs(NodeWalker):
+    def walk(self, item, schema_format):
+        parent = super(NodeWalkerForCleaningRefs, self)
+        return parent.walk(item, schema_format)
+
+    @staticmethod
+    def fix_ref(ref, schema_format):
+        parts = urlparse(ref)
+
+        if parts.scheme or parts.netloc:
+            # only rewrite relative paths
+            return
+
+        if not parts.path:
+            # don't rewrite internal refs
+            return
+
+        if parts.path.startswith('/'):
+            # don't rewrite absolute refs
+            return
+
+        path, ext = os.path.splitext(parts.path)
+        return urlunparse([
+            parts.scheme,
+            parts.netloc,
+            '%s.%s' % (path, schema_format),
+            parts.params,
+            parts.query,
+            parts.fragment,
+            ])
+
+    def _walk_dict_item(self, key, value, schema_format):
+        if key != '$ref':
+            parent = super(NodeWalkerForCleaningRefs, self)
+            return parent._walk_dict_item(key, value, schema_format)
+
+        return self.fix_ref(value, schema_format) or value
 
 
 class YamlRendererFactory(object):
@@ -133,26 +243,34 @@ class YamlRendererFactory(object):
 
 
 def build_swagger_20_swagger_schema_views(config):
+    spec = config.registry.settings['pyramid_swagger.schema20']
+
+    walker = NodeWalkerForRefFiles()
+    all_files = walker.walk(spec)
+
+    file_map = {}
+
     def view_for_swagger_schema(request):
-        settings = config.registry.settings
-        resolved_dict = settings.get('pyramid_swagger.schema20_resolved')
-        if not resolved_dict:
-            spec = settings['pyramid_swagger.schema20']
-            spec_copy = copy.deepcopy(spec.client_spec_dict)
-            resolved_dict = resolve_refs(spec, spec_copy)
-            settings['pyramid_swagger.schema20_resolved'] = resolved_dict
-        return resolved_dict
+        path, ext = os.path.splitext(request.path)
+        ext = ext.lstrip('.')
+        actual_fname = file_map[request.path]
+        with spec.resolver.resolving(actual_fname) as spec_dict:
+            clean_response = strip_xscope(spec_dict)
+            ref_walker = NodeWalkerForCleaningRefs()
+            fixed_spec = ref_walker.walk(clean_response, ext)
+            return fixed_spec
 
-    yield PyramidEndpoint(
-        path='/swagger.json',
-        route_name='pyramid_swagger.swagger20.api_docs.json',
-        view=view_for_swagger_schema,
-        renderer='json',
-    )
-
-    yield PyramidEndpoint(
-        path='/swagger.yaml',
-        route_name='pyramid_swagger.swagger20.api_docs.yaml',
-        view=view_for_swagger_schema,
-        renderer='yaml',
-    )
+    for ref_fname in all_files:
+        ref_fname_parts = os.path.splitext(ref_fname)
+        for schema_format in ['yaml', 'json']:
+            route_name = 'pyramid_swagger.swagger20.api_docs.%s.%s' % (
+                ref_fname.replace('/', '.'), schema_format,
+            )
+            path = '/%s.%s' % (ref_fname_parts[0], schema_format)
+            file_map[path] = ref_fname
+            yield PyramidEndpoint(
+                path=path,
+                route_name=route_name,
+                view=view_for_swagger_schema,
+                renderer=schema_format,
+            )

--- a/pyramid_swagger/tween.py
+++ b/pyramid_swagger/tween.py
@@ -382,6 +382,16 @@ def get_exclude_paths(registry):
     return [re.compile(r) for r in regexes]
 
 
+def is_swagger_documentation_route(route_info):
+    if not route_info:
+        return False
+
+    route = route_info.get('route')
+    if not route:
+        return False
+    return route.name.startswith('pyramid_swagger.swagger20.api_docs.')
+
+
 def should_exclude_request(settings, request, route_info):
     disable_all_validation = not any((
         settings.validate_request,
@@ -391,7 +401,8 @@ def should_exclude_request(settings, request, route_info):
     return (
         disable_all_validation or
         should_exclude_path(settings.exclude_paths, request.path) or
-        should_exclude_route(settings.exclude_routes, route_info)
+        should_exclude_route(settings.exclude_routes, route_info) or
+        is_swagger_documentation_route(route_info)
     )
 
 

--- a/tests/acceptance/api_test.py
+++ b/tests/acceptance/api_test.py
@@ -95,3 +95,4 @@ def test_recursive_swagger_api_external_refs():
     }))
 
     recursive_test_app.get('/swagger.json', status=200)
+    recursive_test_app.get('/external.json', status=200)

--- a/tests/acceptance/api_test.py
+++ b/tests/acceptance/api_test.py
@@ -77,3 +77,21 @@ def test_default_only_serves_up_swagger_20_schema(default_test_app):
     # swagger 1.2 schemas should 404
     for path in ('/api-docs', '/api-docs/sample', '/api-docs/other_sample'):
         default_test_app.get(path, status=404)
+
+
+def test_recursive_swagger_api_internal_refs():
+    recursive_test_app = TestApp(main({}, **{
+        'pyramid_swagger.schema_directory':
+            'tests/sample_schemas/recursive_app/internal/',
+    }))
+
+    recursive_test_app.get('/swagger.json', status=200)
+
+
+def test_recursive_swagger_api_external_refs():
+    recursive_test_app = TestApp(main({}, **{
+        'pyramid_swagger.schema_directory':
+            'tests/sample_schemas/recursive_app/external/',
+    }))
+
+    recursive_test_app.get('/swagger.json', status=200)

--- a/tests/acceptance/relative_ref_test.py
+++ b/tests/acceptance/relative_ref_test.py
@@ -1,7 +1,11 @@
 # -*- coding: utf-8 -*-
+import json
+import os.path
 import pytest
-from webtest import TestApp
+import yaml
 
+from six import BytesIO
+from webtest import TestApp
 from .app import main
 
 
@@ -25,3 +29,55 @@ def test_app(settings):
 def test_running_query_for_relative_ref(test_app):
     response = test_app.get('/sample/path_arg1/resource', params={},)
     assert response.status_code == 200
+
+
+def fix_ref(ref, schema_format):
+    if schema_format == 'json':
+        return ref  # all refs are already yaml
+    return ref.replace('.json', '.%s' % schema_format)
+
+
+def walk_schema_for_refs(schema_item, schema_format):
+    if isinstance(schema_item, dict):
+        for key, value in schema_item.items():
+            if key == '$ref':
+                schema_item[key] = fix_ref(value, schema_format)
+            else:
+                walk_schema_for_refs(value, schema_format)
+    elif isinstance(schema_item, list):
+        for item in schema_item:
+            walk_schema_for_refs(item, schema_format)
+
+
+@pytest.mark.parametrize('schema_format', ['json', 'yaml'])
+def test_swagger_schema_retrieval(schema_format, test_app):
+    here = os.path.dirname(__file__)
+    deserializers = {
+        'json': lambda r: json.loads(r.body.decode('utf-8')),
+        'yaml': lambda r: yaml.load(BytesIO(r.body)),
+    }
+
+    deserializer = deserializers[schema_format]
+
+    expected_files = [
+        'parameters/common',
+        'paths/common',
+        'responses/common',
+        'swagger',
+    ]
+    for expected_file in expected_files:
+        response = test_app.get('/%s.%s' % (expected_file, schema_format))
+        assert response.status_code == 200
+
+        gold_path_parts = [
+            here, '..', 'sample_schemas', 'relative_ref',
+            '%s.json' % expected_file,
+        ]
+        with open(os.path.join(*gold_path_parts)) as f:
+            expected_dict = json.load(f)
+
+        walk_schema_for_refs(expected_dict, schema_format)
+
+        actual_dict = deserializer(response)
+
+        assert actual_dict == expected_dict

--- a/tests/acceptance/yaml_test.py
+++ b/tests/acceptance/yaml_test.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 import base64
+import json
+import yaml
 
 import pytest
 from webtest import TestApp
@@ -49,118 +51,57 @@ def test_user_format_failure_case(testapp_with_base64):
                                 params={'required_arg': 'MQ'},)
 
 
+def validate_json_response(response, expected_dict):
+    assert response.headers['content-type'] == \
+           'application/json; charset=UTF-8'
+    assert json.loads(response.body.decode("utf-8")) == expected_dict
+
+
+def validate_yaml_response(response, expected_dict):
+    assert response.headers['content-type'] == \
+           'application/x-yaml; charset=UTF-8'
+    assert yaml.load(response.body) == expected_dict
+
+
+def fix_ref(ref, schema_format):
+    if schema_format == 'yaml':
+        return ref  # all refs are already yaml
+    return ref.replace('.yaml', '.%s' % schema_format)
+
+
+def walk_schema_for_refs(schema_item, schema_format):
+    if isinstance(schema_item, dict):
+        for key, value in schema_item.items():
+            if key == '$ref':
+                schema_item[key] = fix_ref(value, schema_format)
+            else:
+                walk_schema_for_refs(value, schema_format)
+    elif isinstance(schema_item, list):
+        for item in schema_item:
+            walk_schema_for_refs(item, schema_format)
+
+
 def test_swagger_json_api_doc_route(testapp_with_base64):
-    expected_schema = {
-        'host': 'localhost:9999',
-        'info': {
-            'title': 'Title was not specified',
-            'version': '0.1',
-        },
-        'produces': ['application/json'],
-        'schemes': ['http'],
-        'swagger': '2.0',
-        'paths': {
-            '/sample/{path_arg}/resource': {
-                'get': {
-                    'description': '',
-                    'operationId': 'standard',
-                    'parameters': [
-                        {
-                            'enum': ['path_arg1', 'path_arg2'],
-                            'in': 'path',
-                            'name': 'path_arg',
-                            'required': True,
-                            'type': 'string',
-                        }, {
-                            'format': 'base64',
-                            'in': 'query',
-                            'name': 'required_arg',
-                            'required': True,
-                            'type': 'string',
-                        }, {
-                            'in': 'query',
-                            'name': 'optional_arg',
-                            'required': False,
-                            'type': 'string',
-                        },
-                    ],
-                    'responses': {
-                        '200': {
-                            'description': 'Return a standard_response',
-                            'schema': {
-                                'additionalProperties': False,
-                                'properties': {
-                                    'logging_info': {'type': 'object'},
-                                    'raw_response': {'type': 'string'},
-                                },
-                                'required': [
-                                    'raw_response',
-                                    'logging_info',
-                                ],
-                                'type': 'object',
-                            },
-                        },
-                    },
-                },
-                'post': {
-                    'parameters': [
-                        {
-                            'in': 'path',
-                            'name': 'path_arg',
-                            'required': True,
-                            'type': 'string',
-                        }, {
-                            'in': 'body',
-                            'name': 'request',
-                            'required': True,
-                            'schema': {
-                                'additionalProperties': False,
-                                'properties': {
-                                    'bar': {'type': 'string'},
-                                    'foo': {'type': 'string'},
-                                },
-                                'required': ['foo'],
-                                'type': 'object',
-                            },
-                        },
-                    ],
-                    'responses': {
-                        'default': {
-                            'description': 'test '
-                            'response',
-                            'schema': {
-                                'additionalProperties': False,
-                                'properties': {
-                                    'logging_info': {'type': 'object'},
-                                    'raw_response': {'type': 'string'},
-                                },
-                                'required': [
-                                    'raw_response',
-                                    'logging_info'
-                                ],
-                                'type': 'object',
-                            },
-                        },
-                    },
-                },
-            },
-        },
-    }
+    test_files = [
+        'swagger',
+        'defs',
+    ]
 
-    response = testapp_with_base64.get(
-        '/swagger.json',
-    )
-    assert response.status_code == 200
-    assert response.headers['content-type'] == ('application/json; '
-                                                'charset=UTF-8')
-    import json
-    assert json.loads(response.body.decode("utf-8")) == expected_schema
+    test_formats = [
+        ('yaml', validate_yaml_response),
+        ('json', validate_json_response),
+    ]
 
-    response = testapp_with_base64.get(
-        '/swagger.yaml',
-    )
-    assert response.status_code == 200
-    assert response.headers['content-type'] == ('application/x-yaml; '
-                                                'charset=UTF-8')
-    import yaml
-    assert yaml.load(response.body) == expected_schema
+    for test_file in test_files:
+        for schema_format, validate_schema in test_formats:
+            url = '/%s.%s' % (test_file, schema_format)
+            response = testapp_with_base64.get(url)
+            assert response.status_code == 200
+
+            fname = 'tests/sample_schemas/yaml_app/%s.yaml' % test_file
+            with open(fname, 'r') as f:
+                expected_schema = yaml.load(f)
+
+            walk_schema_for_refs(expected_schema, schema_format)
+
+            validate_schema(response, expected_schema)

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -50,3 +50,18 @@ def test_proper_error_on_missing_api_declaration():
         'tests/sample_schemas/missing_api_declaration/missing.json'
         in str(exc)
     )
+
+
+def test_ignore_absolute_paths():
+    from pyramid_swagger.api import get_path_if_relative
+    assert get_path_if_relative(
+        'http://www.google.com/some/special/schema.json',
+    ) is None
+
+    assert get_path_if_relative(
+        '//www.google.com/some/schema.yaml',
+    ) is None
+
+    assert get_path_if_relative(
+        '/usr/lib/shared/schema.json',
+    ) is None

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -53,6 +53,10 @@ def test_proper_error_on_missing_api_declaration():
 
 
 def test_ignore_absolute_paths():
+    """
+    we don't have the ability to automagically translate these external
+    resources from yaml to json and vice versa, so ignore them altogether.
+    """
     from pyramid_swagger.api import get_path_if_relative
     assert get_path_if_relative(
         'http://www.google.com/some/special/schema.json',

--- a/tests/includeme_test.py
+++ b/tests/includeme_test.py
@@ -43,6 +43,7 @@ def test_bad_schema_not_validated_if_spec_validation_is_disabled(_):
     settings = {
         'pyramid_swagger.schema_directory': 'tests/sample_schemas/bad_app/',
         'pyramid_swagger.enable_swagger_spec_validation': False,
+        'pyramid_swagger.enable_api_doc_views': False,
     }
     mock_config = mock.Mock(
         spec=Configurator, registry=mock.Mock(settings=settings))

--- a/tests/sample_schemas/recursive_app/external/external.json
+++ b/tests/sample_schemas/recursive_app/external/external.json
@@ -1,0 +1,18 @@
+{
+  "widget": {
+    "description": "A widget which may have multiple generations of child widgets",
+    "properties": {
+      "name": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 50
+      },
+      "children": {
+        "type": "array",
+        "items": {
+          "$ref":"#/widget"
+        }
+      }
+    }
+  }
+}

--- a/tests/sample_schemas/recursive_app/external/swagger.json
+++ b/tests/sample_schemas/recursive_app/external/swagger.json
@@ -1,0 +1,38 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Bug demo",
+    "description": "Recursive object definitions cause problems",
+    "version": "0.1.0"
+  },
+  "definitions": {
+    "widget": {
+      "$ref": "external.json#/widget"
+    }
+  },
+  "paths": {
+    "/resources/widget/{code}" : {
+      "parameters" : [
+        {
+          "name": "code",
+          "description": "The CODE value for a widget",
+          "in": "path",
+          "type": "string",
+          "required": true
+        }
+      ],
+      "get": {
+        "summary": "View a single widget",
+        "produces": ["application/json"],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description":"Widget local content (without parents or descendents)",
+            "schema": {"$ref":"external.json#/widget"}
+          },
+          "404": {"description": "The widget does not exist"}
+        }
+      }
+    }
+  }
+}

--- a/tests/sample_schemas/recursive_app/internal/swagger.json
+++ b/tests/sample_schemas/recursive_app/internal/swagger.json
@@ -1,0 +1,51 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Bug demo",
+    "description": "Recursive object definitions cause problems",
+    "version": "0.1.0"
+  },
+  "definitions": {
+    "widget": {
+      "description": "A widget which may have multiple generations of child widgets",
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 50
+        },
+        "children": {
+          "type": "array",
+          "items": {
+            "$ref":"#/definitions/widget"
+          }
+        }
+      }
+    }
+  },
+  "paths": {
+    "/resources/widget/{code}" : {
+      "parameters" : [
+        {
+          "name": "code",
+          "description": "The CODE value for a widget",
+          "in": "path",
+          "type": "string",
+          "required": true
+        }
+      ],
+      "get": {
+        "summary": "View a single widget",
+        "produces": ["application/json"],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description":"Widget local content (without parents or descendents)",
+            "schema": {"$ref":"#/definitions/widget"}
+          },
+          "404": {"description": "The widget does not exist"}
+        }
+      }
+    }
+  }
+}

--- a/tests/tween_test.py
+++ b/tests/tween_test.py
@@ -340,5 +340,9 @@ def test_get_swagger12_objects_if_both_present_but_route_not_in_prefer20(
 
 
 def test_is_swagger_documentation_route_without_route_is_safe():
+    """
+    Not sure if `None` is an option for the `route_info` dict, but make
+    sure nothing crashes in that possible scenario.
+    """
     from pyramid_swagger.tween import is_swagger_documentation_route
     assert is_swagger_documentation_route(None) is False

--- a/tests/tween_test.py
+++ b/tests/tween_test.py
@@ -337,3 +337,8 @@ def test_get_swagger12_objects_if_both_present_but_route_not_in_prefer20(
     swagger_handler, spec = get_swagger_objects(settings, route_info, registry)
     assert 'swagger12_handler' in str(swagger_handler)
     assert 'schema12' == spec
+
+
+def test_is_swagger_documentation_route_without_route_is_safe():
+    from pyramid_swagger.tween import is_swagger_documentation_route
+    assert is_swagger_documentation_route(None) is False


### PR DESCRIPTION
# High level overview
This adds support for serving up all the external files that make up a swagger schema, and the ability to translate between json and yaml transparently.

In other words, if you have a `swagger.yaml` file that references a `models.json` file, all of the following requests return files:
- `GET /swagger.yaml` (the external reference will be rewritten to `{$ref: models.yaml}` to match the requested format
- `GET /swagger.json` (with the `$ref` rewritten to `models.json`)
- `GET /models.json`
- `GET /models.yaml`

This also inherently solves the recursive schema issue, #160 

# Low level overview
This was a little tougher to accomplish than repackaging the entire schema as a single file. The changes can be broken down into three chunks: 
a) creating all the appropriate routes, 
b) serving up all the schemas
c) hiding the api doc routes from the tween

## Routes
This requires walking the `swagger.json` for all `$ref` nodes, and identifying which urls should be served by us. I decided that only relative $refs should be served (if a $ref is hosted on a different website, we can't rewrite the contents of it easily). `NodeWalkerForRefFiles` is the class that implements finding all the relative file refs. 

## Serving up the schemas
This requires rewriting the `$refs` before returning the dict, in order to keep the client consistent. A client requesting a `swagger.json` file would be very confused if it received a `models.yaml` file, I think. The class responsible for walking the schema and rewriting the `$refs` is `NodeWalkerForCleaningRefs`. 

## Hiding the API doc route from the tween
This was implemented in `is_swagger_documentation_route`. All the api doc routes have the same prefix; this finds those and skips schema validation for those.