### PR TITLE
Fix RefResolutionError when building swagger schema

### DIFF
--- a/pyramid_swagger/api.py
+++ b/pyramid_swagger/api.py
@@ -98,10 +98,9 @@ def build_swagger_12_api_declaration_view(api_declaration_json):
 
 
 def resolve_ref(spec, url):
-    with spec.resolver.resolving(url):
-        abs_path, spec_dict = spec.resolver.resolve(url)
-        spec_dict = copy.deepcopy(spec_dict)
-        return resolve_refs(spec, spec_dict)
+    with spec.resolver.resolving(url) as resolved_spec_dict:
+        resolved_spec_dict = copy.deepcopy(resolved_spec_dict)
+        return resolve_refs(spec, resolved_spec_dict)
 
 
 def resolve_refs(spec, val):

--- a/tests/acceptance/relative_ref_test.py
+++ b/tests/acceptance/relative_ref_test.py
@@ -25,3 +25,8 @@ def test_app(settings):
 def test_running_query_for_relative_ref(test_app):
     response = test_app.get('/sample/path_arg1/resource', params={},)
     assert response.status_code == 200
+
+
+def test_build_swagger_20_schema_with_relative_refs(test_app):
+    response = test_app.get('/swagger.json', params={},)
+    assert response.status_code == 200


### PR DESCRIPTION
Building a swagger schema (i.e. GET requesting /swagger.json) would lead
to a RefResolutionError if the swagger.json contains $refs

The spec.resolver.resolving context manager resolves the ref url and pushes it to the resolver's resolution_scope: https://github.com/Julian/jsonschema/blob/master/jsonschema/validators.py#L318

This causes the spec.resolver.resolve(url) call in resolve_ref to get a RefResolutionError since it's trying to resolve the same ref after the ref url has been pushed to resolution_scope. Getting rid of the spec.resolver.resolve and getting the spec_dict directly from the context manager yield seems to fix this issue

What's Happening:
spec.resolver.resolution_scope = {base_path}
url = {ref_path}
Calling spec.resolver.resolve(url) returns {base_path}/{ref_path}

After with spec.resolver.resolve(url):
spec.resolver.resolution_scope = {base_path}/{ref_path}
Calling spec.resolver.resolve(url) returns {base_path}/{ref_path}/{ref_path} leading to a RefResolutionError
