### PR TITLE
Add serve_dereferenced_swagger_schema parameter

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -71,6 +71,12 @@ A few relevant settings for your `Pyramid .ini file <http://docs.pylonsproject.o
         # below for more details
         pyramid_swagger.generate_resource_listing = false
 
+        # Enable/disable serving the entire dereferenced swagger schema in
+        # a single http call. This can be slow for larger schemas and will
+        # not work for infinitely recursive refs
+        # Default: False
+        pyramid_swagger.dereference_served_schema = False
+
 
 Note that, equivalently, you can add these settings during webapp configuration:
 

--- a/tests/sample_schemas/relative_ref/dereferenced_swagger.json
+++ b/tests/sample_schemas/relative_ref/dereferenced_swagger.json
@@ -1,0 +1,77 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "title": "Title was not specified",
+        "version": "0.1"
+    },
+    "produces": ["application/json"],
+    "paths": {
+        "/no_models": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Return a standard_response",
+                        "schema": {
+                            "type": "object",
+                            "required": [
+                                "raw_response",
+                                "logging_info"
+                            ],
+                            "additionalProperties": false,
+                            "properties": {
+                                "raw_response": {
+                                    "type": "string"
+                                },
+                                "logging_info": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "",
+                "operationId": "no_models_get"
+            }
+        },
+        "/sample/{path_arg}/resource": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Return a standard_response",
+                        "schema": {
+                            "type": "object",
+                            "required": [
+                                "raw_response",
+                                "logging_info"
+                            ],
+                            "additionalProperties": false,
+                            "properties": {
+                                "raw_response": {
+                                    "type": "string"
+                                },
+                                "logging_info": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "",
+                "operationId": "standard",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "path_arg",
+                        "required": true,
+                        "type": "string",
+                        "enum": ["path_arg1", "path_arg2"]
+                    }
+                ]
+            }
+        }
+    },
+    "host": "localhost:9999",
+    "schemes": [
+        "http"
+    ]
+}

--- a/tests/sample_schemas/relative_ref/paths/common.json
+++ b/tests/sample_schemas/relative_ref/paths/common.json
@@ -1,29 +1,29 @@
 {
     "no_models": {
-      "get": {
-        "responses": {
-          "200": {
-              "$ref": "../responses/common.json#/200"
-          }
-        },
-        "description": "",
-        "operationId": "no_models_get"
-      }
+        "get": {
+            "responses": {
+                "200": {
+                    "$ref": "../responses/common.json#/200"
+                }
+            },
+            "description": "",
+            "operationId": "no_models_get"
+        }
     },
     "sample_resource": {
-      "get": {
-        "responses": {
-          "200": {
-              "$ref": "../responses/common.json#/200"
-          }
-        },
-        "description": "",
-        "operationId": "standard",
-        "parameters": [
-          {
-            "$ref": "../parameters/common.json#/path_arg"
-          }
-        ]
-      }
+        "get": {
+            "responses": {
+                "200": {
+                    "$ref": "../responses/common.json#/200"
+                }
+            },
+            "description": "",
+            "operationId": "standard",
+            "parameters": [
+                {
+                    "$ref": "../parameters/common.json#/path_arg"
+                }
+            ]
+        }
     }
 }

--- a/tests/sample_schemas/relative_ref/responses/common.json
+++ b/tests/sample_schemas/relative_ref/responses/common.json
@@ -1,21 +1,21 @@
 {
     "200": {
-      "description": "Return a standard_response",
-      "schema": {
-          "type": "object",
-          "required": [
-            "raw_response",
-            "logging_info"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "raw_response": {
-              "type": "string"
-            },
-            "logging_info": {
-              "type": "object"
+        "description": "Return a standard_response",
+        "schema": {
+            "type": "object",
+            "required": [
+                "raw_response",
+                "logging_info"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "raw_response": {
+                    "type": "string"
+                },
+                "logging_info": {
+                    "type": "object"
+                }
             }
-          }
-      }
+        }
     }
 }

--- a/tests/sample_schemas/relative_ref/swagger.json
+++ b/tests/sample_schemas/relative_ref/swagger.json
@@ -1,20 +1,20 @@
 {
-  "swagger": "2.0",
-  "info": {
-    "title": "Title was not specified",
-    "version": "0.1"
-  },
-  "produces": ["application/json"],
-  "paths": {
-    "/no_models": {
-        "$ref": "paths/common.json#/no_models"
+    "swagger": "2.0",
+    "info": {
+        "title": "Title was not specified",
+        "version": "0.1"
     },
-    "/sample/{path_arg}/resource": {
-        "$ref": "paths/common.json#/sample_resource"
-    }
-  },
-  "host": "localhost:9999",
-  "schemes": [
-    "http"
-  ]
+    "produces": ["application/json"],
+    "paths": {
+        "/no_models": {
+            "$ref": "paths/common.json#/no_models"
+        },
+        "/sample/{path_arg}/resource": {
+            "$ref": "paths/common.json#/sample_resource"
+        }
+    },
+    "host": "localhost:9999",
+    "schemes": [
+        "http"
+    ]
 }


### PR DESCRIPTION
Add an option to serve full swagger schemas with all schema refs
resolved (The behavior prior to pyramid_swagger 2.3.0-rc2).

During a deployment where servers are distributed, there can be a transient period where some servers have an old version of a schema and a new version of a schema.  In pyramid_swagger 2.3.0-rc2, a schema is built from multiple requests from each ref.  If a new schema tries to resolve a ref but points to an old schema (or vice versa) during the transient deploy period, there can be issues in the resulting schema.  This pull request adds an option to use the old behavior prior to 2.3.0-rc2 where the server resolves all the refs and serves the fully dereferenced schema upon a request for swagger.{json, yaml}