### PR TITLE
Allow recursive references in single file specs aggregation.

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -71,8 +71,10 @@ A few relevant settings for your `Pyramid .ini file <http://docs.pylonsproject.o
         # below for more details
         pyramid_swagger.generate_resource_listing = false
 
-        # Enable/disable serving the entire dereferenced swagger schema in
-        # a single http call. This can be slow for larger schemas
+        # Enable/disable serving the dereferenced swagger schema in
+        # a single http call. This can be slow for larger schemas.
+        # Note: It is not suggested to use it with Python 2.6. Known issues with
+        #       os.path.relpath could affect the proper behaviour.
         # Default: False
         pyramid_swagger.dereference_served_schema = False
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -72,8 +72,7 @@ A few relevant settings for your `Pyramid .ini file <http://docs.pylonsproject.o
         pyramid_swagger.generate_resource_listing = false
 
         # Enable/disable serving the entire dereferenced swagger schema in
-        # a single http call. This can be slow for larger schemas and will
-        # not work for infinitely recursive refs
+        # a single http call. This can be slow for larger schemas
         # Default: False
         pyramid_swagger.dereference_served_schema = False
 

--- a/pyramid_swagger/api.py
+++ b/pyramid_swagger/api.py
@@ -213,22 +213,6 @@ def _get_absolute_link(spec, resource_path_fragment, current_path=''):
         return urlparse(resource_path_fragment)
 
 
-def _relpath(path, start):
-    """Return a relative version of a path
-    NOTE: Code duplicated from Python 2.7.9 implementation because the
-    default implementation available on Python 2.6.9 is bugged.
-    """
-    start_list = [x for x in os.path.abspath(start).split(os.path.sep) if x]
-    path_list = [x for x in os.path.abspath(path).split(os.path.sep) if x]
-
-    # Work out how much of the filepath is shared by start and path.
-    i = len(os.path.commonprefix([start_list, path_list]))
-
-    rel_list = [os.path.pardir] * (len(start_list) - i) + path_list[i:]
-
-    return os.path.join(*rel_list)
-
-
 def _get_target_url(spec, target, current_path=''):
     """
     Generate a well formatted URL for the required target.
@@ -269,7 +253,7 @@ def _get_target_url(spec, target, current_path=''):
         # Hiding of the internal server paths information.
         # A path relative to the swagger.{json,yaml} is returned
         target_url = urlparse('{path}#{fragment}'.format(
-            path=_relpath(target_url.path, spec_dir),
+            path=os.path.relpath(target_url.path, spec_dir),
             fragment=target_url.fragment,
         ))
 

--- a/tests/acceptance/recursive_app_test.py
+++ b/tests/acceptance/recursive_app_test.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+import json
+import pytest
+import yaml
+
+from six import BytesIO
+from webtest import TestApp
+from .app import main
+
+
+DESERIALIZERS = {
+    'json': lambda r: json.loads(r.body.decode('utf-8')),
+    'yaml': lambda r: yaml.load(BytesIO(r.body)),
+}
+
+
+@pytest.fixture
+def settings():
+    dir_path = 'tests/sample_schemas/recursive_app/external/'
+    return {
+        'pyramid_swagger.schema_directory': dir_path,
+        'pyramid_swagger.enable_request_validation': True,
+        'pyramid_swagger.enable_swagger_spec_validation': True,
+        'pyramid_swagger.swagger_versions': ['2.0']
+    }
+
+
+@pytest.fixture
+def test_app_deref(settings):
+    """Fixture for setting up a Swagger 2.0 version of the test test_app
+    test app serves swagger schemas with refs dereferenced."""
+    settings['pyramid_swagger.dereference_served_schema'] = True
+    return TestApp(main({}, **settings))
+
+
+@pytest.mark.parametrize('schema_format', ['json'])
+def test_dereferenced_swagger_schema_bravado_client(
+        schema_format,
+        test_app_deref,
+):
+    from bravado.client import SwaggerClient
+
+    response = test_app_deref.get('/swagger.{0}'.format(schema_format))
+    deserializer = DESERIALIZERS[schema_format]
+    specs = deserializer(response)
+
+    SwaggerClient.from_spec(specs)

--- a/tests/acceptance/relative_ref_test.py
+++ b/tests/acceptance/relative_ref_test.py
@@ -2,6 +2,7 @@
 import json
 import os.path
 import pytest
+import re
 import yaml
 
 from six import BytesIO
@@ -147,5 +148,8 @@ def test_dereferenced_swagger_schema_retrieval(schema_format, test_app_deref):
     deserializer = DESERIALIZERS[schema_format]
     actual_dict = deserializer(response)
 
-    assert '"$ref"' not in json.dumps(actual_dict)
+    # pattern for references outside the current file
+    ref_pattern = re.compile('("\$ref": "[^#][^"]*")')
+    assert ref_pattern.findall(json.dumps(actual_dict)) == []
+
     assert actual_dict == expected_dict

--- a/tests/marshaller_test.py
+++ b/tests/marshaller_test.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+from bravado_core.spec import Spec
+import pytest
+
+from six.moves.urllib.parse import urlparse
+
+from pyramid_swagger.api import _get_target, _marshal_target, _unmarshal_target
+
+
+@pytest.fixture
+def bravado_spec():
+    return Spec(
+        spec_dict={},
+        origin_url='/swagger.json',
+    )
+
+
+@pytest.mark.parametrize(
+    'target',
+    [
+        'file:///dir1/dir2/file.json#/path1/path2/resource',
+        'dir1/dir2/file.json#/path1/path2/resource',
+        'http://hostname/dir1/dir2/file.json#/path1/path2/resource',
+        'https://hostname/dir1/dir2/file.json#/path1/path2/resource',
+    ]
+)
+def test_marshaller_not_raises(target):
+    assert target == _unmarshal_target(_marshal_target(urlparse(target)))
+
+
+@pytest.mark.parametrize(
+    'target',
+    [
+        '',
+        'xhttps://hostname/dir1/dir2/file.json#/path1/path2/resource',
+    ]
+)
+def test_marshaller_raises(target):
+    with pytest.raises(ValueError):
+        _marshal_target(urlparse(target))
+
+
+@pytest.mark.parametrize(
+    'target',
+    [
+        'xhttps.hostname..dir1..dir2..file.json|..path1..path2..resource',
+    ]
+)
+def test_unmarshaller_raises(target):
+    with pytest.raises(ValueError):
+        _unmarshal_target(target)
+
+
+@pytest.mark.parametrize(
+    'current_path, target, expected',
+    [
+        (
+            # with url it should be the same
+            'swagger.json',
+            'http://hostname/dir1/dir2/file.json#/path1/path2/resource',
+            'http://hostname/dir1/dir2/file.json#/path1/path2/resource',
+        ),
+        (
+            # relative directory respect to the swagger file
+            '/dir1/another1.json',
+            '../dir2/other2.json#/path/resource',
+            'dir2/other2.json#/path/resource',
+        ),
+        (
+            'file:///swagger.json',
+            '#/path/resource',
+            'swagger.json#/path/resource',
+        ),
+    ]
+)
+def test_target(bravado_spec, current_path, target, expected):
+    assert \
+        _get_target(bravado_spec, target, current_path) == urlparse(expected)
+
+
+@pytest.mark.parametrize(
+    'target',
+    [
+        '',
+        'xhttps://hostname/dir1/dir2/file.json#/path1/path2/resource',
+    ]
+)
+def test_target_raises(bravado_spec, target):
+    with pytest.raises(ValueError):
+        _get_target(bravado_spec, target)

--- a/tests/marshaller_test.py
+++ b/tests/marshaller_test.py
@@ -4,7 +4,9 @@ import pytest
 
 from six.moves.urllib.parse import urlparse
 
-from pyramid_swagger.api import _get_target, _marshal_target, _unmarshal_target
+from pyramid_swagger.api import _get_target_url
+from pyramid_swagger.api import _marshal_target
+from pyramid_swagger.api import _unmarshal_target
 
 
 @pytest.fixture
@@ -74,8 +76,8 @@ def test_unmarshaller_raises(target):
     ]
 )
 def test_target(bravado_spec, current_path, target, expected):
-    assert \
-        _get_target(bravado_spec, target, current_path) == urlparse(expected)
+    assert _get_target_url(bravado_spec, target, current_path) \
+           == urlparse(expected)
 
 
 @pytest.mark.parametrize(
@@ -87,4 +89,4 @@ def test_target(bravado_spec, current_path, target, expected):
 )
 def test_target_raises(bravado_spec, target):
     with pytest.raises(ValueError):
-        _get_target(bravado_spec, target)
+        _get_target_url(bravado_spec, target)

--- a/tests/marshaller_test.py
+++ b/tests/marshaller_test.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from bravado_core.spec import Spec
 import pytest
+import sys
 
 from six.moves.urllib.parse import urlparse
 
@@ -53,25 +54,32 @@ def test_unmarshaller_raises(target):
         _unmarshal_target(target)
 
 
+@pytest.mark.skipif(
+    sys.version_info < (2, 7),
+    reason="There is a knwon Python 2.6 issue on the implementation of "
+           "os.path.relpath (http://bugs.python.org/issue5117). "
+           "Additional information on pyramid_swagger PR 171. "
+           "https://github.com/striglia/pyramid_swagger/pull/171"
+)
 @pytest.mark.parametrize(
     'current_path, target, expected',
     [
         (
-            # with url it should be the same
-            'swagger.json',
-            'http://hostname/dir1/dir2/file.json#/path1/path2/resource',
-            'http://hostname/dir1/dir2/file.json#/path1/path2/resource',
+                # with url it should be the same
+                'swagger.json',
+                'http://hostname/dir1/dir2/file.json#/path1/path2/resource',
+                'http://hostname/dir1/dir2/file.json#/path1/path2/resource',
         ),
         (
-            # relative directory respect to the swagger file
-            '/dir1/another1.json',
-            '../dir2/other2.json#/path/resource',
-            'dir2/other2.json#/path/resource',
+                # relative directory respect to the swagger file
+                '/dir1/another1.json',
+                '../dir2/other2.json#/path/resource',
+                'dir2/other2.json#/path/resource',
         ),
         (
-            'file:///swagger.json',
-            '#/path/resource',
-            'swagger.json#/path/resource',
+                'file:///swagger.json',
+                '#/path/resource',
+                'swagger.json#/path/resource',
         ),
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ deps =
     ordereddict
     webtest
     pyramid15: pyramid<=1.5.4
+    bravado
 
 commands =
     coverage run --source=pyramid_swagger/ --omit=pyramid_swagger/__about__.py -m pytest --capture=no --strict {posargs:tests/}


### PR DESCRIPTION
With the last release was added the ``dereference_served_schema`` parameter.
As described by the documentation the parameter is not working well in case of recursive model definition.

The PR includes the possibility to generate a single file swagger specs even in case of recursive model definition. It reaches the goal allowing local references only for the [definition objects](http://swagger.io/specification/#definitionsObject).

The generated specs are tested respect to the [bravado](https://github.com/Yelp/bravado) client.

Ping: @striglia, @lucagiovagnoli, @sjaensch
