### PR TITLE
Tox file improvement

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,8 @@ deps =
     webtest
     pyramid15: pyramid<=1.5.4
     bravado
+    # Python >= 2.7 is needed by twisted >= 15.5
+    py26: twisted >= 14.0.0, < 15.5
 
 commands =
     coverage run --source=pyramid_swagger/ --omit=pyramid_swagger/__about__.py -m pytest --capture=no --strict {posargs:tests/}


### PR DESCRIPTION
Users running tests with Python 2.6 could have problems related to twisted that ends into ``ImportError: Twisted requires Python 2.7 or later.``.

The PR is solving this issue limiting the twisted version to 15.5 in case of Python 2.6.