### PR TITLE
Fix pytest 3 errors and warnings, add version requirement

### DIFF
--- a/tests/acceptance/api_test.py
+++ b/tests/acceptance/api_test.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import pytest
-from webtest import TestApp
+from webtest import TestApp as App
 
 from .app import main
 
@@ -15,21 +15,21 @@ def settings():
 
 @pytest.fixture
 def default_test_app(settings):
-    return TestApp(main({}, **settings))
+    return App(main({}, **settings))
 
 
 @pytest.fixture
 def swagger_20_test_app(settings):
     """Fixture for setting up a Swagger 2.0 version of the test test_app."""
     settings['pyramid_swagger.swagger_versions'] = ['2.0']
-    return TestApp(main({}, **settings))
+    return App(main({}, **settings))
 
 
 @pytest.fixture
 def swagger_12_test_app(settings):
     """Fixture for setting up a Swagger 1.2 version of the test test_app."""
     settings['pyramid_swagger.swagger_versions'] = ['1.2']
-    return TestApp(main({}, **settings))
+    return App(main({}, **settings))
 
 
 @pytest.fixture
@@ -38,7 +38,7 @@ def swagger_12_and_20_test_app(settings):
     test test_app.
     """
     settings['pyramid_swagger.swagger_versions'] = ['1.2', '2.0']
-    return TestApp(main({}, **settings))
+    return App(main({}, **settings))
 
 
 def test_12_api_docs(swagger_12_test_app):
@@ -80,7 +80,7 @@ def test_default_only_serves_up_swagger_20_schema(default_test_app):
 
 
 def test_recursive_swagger_api_internal_refs():
-    recursive_test_app = TestApp(main({}, **{
+    recursive_test_app = App(main({}, **{
         'pyramid_swagger.schema_directory':
             'tests/sample_schemas/recursive_app/internal/',
     }))
@@ -89,7 +89,7 @@ def test_recursive_swagger_api_internal_refs():
 
 
 def test_recursive_swagger_api_external_refs():
-    recursive_test_app = TestApp(main({}, **{
+    recursive_test_app = App(main({}, **{
         'pyramid_swagger.schema_directory':
             'tests/sample_schemas/recursive_app/external/',
     }))

--- a/tests/acceptance/format_test.py
+++ b/tests/acceptance/format_test.py
@@ -2,7 +2,7 @@
 import base64
 
 import pytest
-from webtest import TestApp
+from webtest import TestApp as App
 
 from .app import main
 from pyramid_swagger.tween import SwaggerFormat
@@ -32,7 +32,7 @@ def testapp_with_base64(settings, user_format):
     """Fixture for setting up a Swagger 2.0 version of the test testapp."""
     settings['pyramid_swagger.swagger_versions'] = ['2.0']
     settings['pyramid_swagger.user_formats'] = [user_format]
-    return TestApp(main({}, **settings))
+    return App(main({}, **settings))
 
 
 def test_user_format_happy_case(testapp_with_base64):

--- a/tests/acceptance/invalid_file_test.py
+++ b/tests/acceptance/invalid_file_test.py
@@ -2,7 +2,7 @@
 import base64
 
 import pytest
-from webtest import TestApp
+from webtest import TestApp as App
 
 from .app import main
 from pyramid_swagger.tween import SwaggerFormat
@@ -34,4 +34,4 @@ def test_invalid_file_extension(settings, yaml_app):
     settings['pyramid_swagger.user_formats'] = [yaml_app]
 
     with pytest.raises(Exception):
-        TestApp(main({}, **settings))
+        App(main({}, **settings))

--- a/tests/acceptance/prefer_20_routes_test.py
+++ b/tests/acceptance/prefer_20_routes_test.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import pytest
-from webtest import TestApp
+from webtest import TestApp as App
 
 from .app import main
 
@@ -20,7 +20,7 @@ def settings():
 def test_app_with_no_prefer_conf(settings):
     """Fixture for setting up a Swagger 2.0 version with no
     `prefer_20_routes` option added to settings."""
-    return TestApp(main({}, **settings))
+    return App(main({}, **settings))
 
 
 @pytest.fixture
@@ -28,7 +28,7 @@ def test_app_with_prefer_conf(settings):
     """Fixture for setting up a Swagger 2.0 version with a particular route
     `standard` added to `prefer_20_routes` option."""
     settings['pyramid_swagger.prefer_20_routes'] = ['standard']
-    return TestApp(main({}, **settings))
+    return App(main({}, **settings))
 
 
 def test_failure_with_no_prefer_config_case(test_app_with_no_prefer_conf):

--- a/tests/acceptance/recursive_app_test.py
+++ b/tests/acceptance/recursive_app_test.py
@@ -4,7 +4,7 @@ import pytest
 import yaml
 
 from six import BytesIO
-from webtest import TestApp
+from webtest import TestApp as App
 from .app import main
 
 
@@ -30,7 +30,7 @@ def test_app_deref(settings):
     """Fixture for setting up a Swagger 2.0 version of the test test_app
     test app serves swagger schemas with refs dereferenced."""
     settings['pyramid_swagger.dereference_served_schema'] = True
-    return TestApp(main({}, **settings))
+    return App(main({}, **settings))
 
 
 @pytest.mark.parametrize('schema_format', ['json'])

--- a/tests/acceptance/relative_ref_test.py
+++ b/tests/acceptance/relative_ref_test.py
@@ -6,7 +6,7 @@ import re
 import yaml
 
 from six import BytesIO
-from webtest import TestApp
+from webtest import TestApp as App
 from .app import main
 
 
@@ -30,7 +30,7 @@ def settings():
 @pytest.fixture
 def test_app(settings):
     """Fixture for setting up a Swagger 2.0 version of the test test_app."""
-    return TestApp(main({}, **settings))
+    return App(main({}, **settings))
 
 
 @pytest.fixture
@@ -38,7 +38,7 @@ def test_app_deref(settings):
     """Fixture for setting up a Swagger 2.0 version of the test test_app
     test app serves swagger schemas with refs dereferenced."""
     settings['pyramid_swagger.dereference_served_schema'] = True
-    return TestApp(main({}, **settings))
+    return App(main({}, **settings))
 
 
 def test_running_query_for_relative_ref(test_app):

--- a/tests/acceptance/request_test.py
+++ b/tests/acceptance/request_test.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from contextlib import contextmanager
-from _pytest.python import FixtureRequest
+from _pytest.fixtures import FixtureRequest
 
 from mock import Mock
 from pyramid.httpexceptions import exception_response
@@ -13,7 +13,7 @@ import simplejson
 def test_app(request, **overrides):
     """Fixture for setting up a test test_app with particular settings."""
     from .app import main
-    from webtest import TestApp
+    from webtest import TestApp as App
     settings = dict({
         'pyramid_swagger.schema_directory': 'tests/sample_schemas/good_app/',
         'pyramid_swagger.enable_request_validation': True,
@@ -22,7 +22,7 @@ def test_app(request, **overrides):
         'pyramid_swagger.swagger_versions': request.param},
         **overrides
     )
-    return TestApp(main({}, **settings))
+    return App(main({}, **settings))
 
 
 @contextmanager

--- a/tests/acceptance/response20_test.py
+++ b/tests/acceptance/response20_test.py
@@ -4,7 +4,7 @@
 # Based on request_test.py (Swagger 1.2 tests). Differences made it hard for
 # a single codebase to exercise both Swagger 1.2 and 2.0 responses.
 #
-from _pytest.python import FixtureRequest
+from _pytest.fixtures import FixtureRequest
 from mock import patch, Mock
 from pyramid.interfaces import IRoutesMapper
 from pyramid.response import Response

--- a/tests/acceptance/response_test.py
+++ b/tests/acceptance/response_test.py
@@ -1,5 +1,5 @@
 from contextlib import contextmanager
-from _pytest.python import FixtureRequest
+from _pytest.fixtures import FixtureRequest
 
 import mock
 from mock import Mock

--- a/tests/acceptance/yaml_test.py
+++ b/tests/acceptance/yaml_test.py
@@ -4,7 +4,7 @@ import json
 import yaml
 
 import pytest
-from webtest import TestApp
+from webtest import TestApp as App
 
 from .app import main
 from pyramid_swagger.tween import SwaggerFormat
@@ -35,7 +35,7 @@ def testapp_with_base64(settings, yaml_app):
     """Fixture for setting up a Swagger 2.0 version of the test testapp."""
     settings['pyramid_swagger.swagger_versions'] = ['2.0']
     settings['pyramid_swagger.user_formats'] = [yaml_app]
-    return TestApp(main({}, **settings))
+    return App(main({}, **settings))
 
 
 def test_user_format_happy_case(testapp_with_base64):

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist = py26,py27,py33,py34,py35,{py27,py35}-pyramid15,pep8
 deps =
     coverage
     mock
-    pytest
+    pytest>=3
     ordereddict
     webtest
     pyramid15: pyramid<=1.5.4


### PR DESCRIPTION
The class FixtureRequest has moved in pytest 3, causing the tests to fail. Also there were warnings since pytest assumed TestApp was a class that contains tests.