### PR TITLE
Fix installation issue with Python 3 on systems with POSIX locale

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+2.3.0 (2016-09-23)
+++++++++++++++++++
+* Fix installation with Python 3 on systems using a POSIX/ASCII locale
+
 2.3.0-rc3 (2016-06-28)
 ++++++++++++++++++++++
 * Adds ``dereference_served_schema`` config flag to force served spec to be a

--- a/pyramid_swagger/__about__.py
+++ b/pyramid_swagger/__about__.py
@@ -13,7 +13,7 @@ __title__ = "pyramid_swagger"
 __summary__ = "Swagger tools for use in pyramid webapps"
 __uri__ = "https://github.com/striglia/pyramid_swagger"
 
-__version__ = "2.3.0-rc3"
+__version__ = "2.3.0"
 
 __author__ = "Scott Triglia"
 __email__ = "scott.triglia@gmail.com"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,6 @@
+[metadata]
+description-file = README.rst
+
+[wheel]
+universal = True
+

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+import io
 import os
 
 from setuptools import find_packages
@@ -9,7 +10,7 @@ about = {}
 with open(os.path.join(base_dir, "pyramid_swagger", "__about__.py")) as f:
     exec(f.read(), about)
 
-with open(os.path.join(base_dir, "README.rst")) as f:
+with io.open(os.path.join(base_dir, "README.rst"), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(


### PR DESCRIPTION
On Python 3, reading files returns unicode strings. If no encoding is specified when opening the file then the system locale is used for decoding file contents. If that locale is ASCII (POSIX) then installation of pyramid_swagger fails since README.rst contains the non-ASCII © character.

This PR also prepares the 2.3.0 release. The release candidates have seen some heavy internal use, I think we're good to go.