### PR TITLE
Fix error, test failures due to new webob not returning content type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: python
 env:
-- TOX_ENV=py26
 - TOX_ENV=py27
 - TOX_ENV=py34
 - TOX_ENV=py27-pyramid15

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,5 +1,8 @@
 Changelog
 =========
+2.3.1 (2017-XX-XX)
+++++++++++++++++++
+* Fix issue with missing content type when using webob >= 1.7 (see #185)
 
 2.3.0 (2016-09-27)
 ++++++++++++++++++

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@ Changelog
 =========
 2.3.1 (2017-XX-XX)
 ++++++++++++++++++
+* Remove support for Python 2.6, newer Pyramid versions don't support it either
 * Fix issue with missing content type when using webob >= 1.7 (see #185)
 
 2.3.0 (2016-09-27)

--- a/pyramid_swagger/tween.py
+++ b/pyramid_swagger/tween.py
@@ -543,9 +543,9 @@ def validate_response(response, validator_map):
 
 def prepare_body(response):
     # content_type and charset must both be set to access response.text
-    if response.content_type is None or response.charset is None:
+    if not response.content_type:
         raise ResponseValidationError(
-            'Response validation error: Content-Type and charset must be set'
+            'Response validation error: Content-Type must be set'
         )
 
     if 'application/json' in response.content_type:

--- a/pyramid_swagger/tween.py
+++ b/pyramid_swagger/tween.py
@@ -542,7 +542,7 @@ def validate_response(response, validator_map):
 
 
 def prepare_body(response):
-    # content_type and charset must both be set to access response.text
+    # content_type must be set to access response.text
     if not response.content_type:
         raise ResponseValidationError(
             'Response validation error: Content-Type must be set'

--- a/tests/acceptance/yaml_test.py
+++ b/tests/acceptance/yaml_test.py
@@ -60,8 +60,7 @@ def validate_json_response(response, expected_dict):
 
 
 def validate_yaml_response(response, expected_dict):
-    assert response.headers['content-type'] == \
-           'application/x-yaml; charset=UTF-8'
+    assert response.headers['content-type'] == 'application/x-yaml; charset=UTF-8'
     assert yaml.load(response.body) == expected_dict
 
 

--- a/tests/acceptance/yaml_test.py
+++ b/tests/acceptance/yaml_test.py
@@ -52,8 +52,10 @@ def test_user_format_failure_case(testapp_with_base64):
 
 
 def validate_json_response(response, expected_dict):
-    assert response.headers['content-type'] == \
-           'application/json; charset=UTF-8'
+    # webob < 1.7 returns the charset, webob >= 1.7 does not
+    # see https://github.com/striglia/pyramid_swagger/issues/185
+    assert response.headers['content-type'] in \
+        ('application/json', 'application/json; charset=UTF-8')
     assert json.loads(response.body.decode("utf-8")) == expected_dict
 
 

--- a/tests/marshaller_test.py
+++ b/tests/marshaller_test.py
@@ -65,27 +65,26 @@ def test_unmarshaller_raises(target):
     'current_path, target, expected',
     [
         (
-                # with url it should be the same
-                'swagger.json',
-                'http://hostname/dir1/dir2/file.json#/path1/path2/resource',
-                'http://hostname/dir1/dir2/file.json#/path1/path2/resource',
+            # with url it should be the same
+            'swagger.json',
+            'http://hostname/dir1/dir2/file.json#/path1/path2/resource',
+            'http://hostname/dir1/dir2/file.json#/path1/path2/resource',
         ),
         (
-                # relative directory respect to the swagger file
-                '/dir1/another1.json',
-                '../dir2/other2.json#/path/resource',
-                'dir2/other2.json#/path/resource',
+            # relative directory respect to the swagger file
+            '/dir1/another1.json',
+            '../dir2/other2.json#/path/resource',
+            'dir2/other2.json#/path/resource',
         ),
         (
-                'file:///swagger.json',
-                '#/path/resource',
-                'swagger.json#/path/resource',
+            'file:///swagger.json',
+            '#/path/resource',
+            'swagger.json#/path/resource',
         ),
     ]
 )
 def test_target(bravado_spec, current_path, target, expected):
-    assert _get_target_url(bravado_spec, target, current_path) \
-           == urlparse(expected)
+    assert _get_target_url(bravado_spec, target, current_path) == urlparse(expected)
 
 
 @pytest.mark.parametrize(

--- a/tests/tween_test.py
+++ b/tests/tween_test.py
@@ -269,7 +269,7 @@ def registry():
     config = {
         'pyramid_swagger.schema12': None,
         'pyramid_swagger.schema20': None,
-        }
+    }
     return Mock(settings=config)
 
 

--- a/tests/tween_test.py
+++ b/tests/tween_test.py
@@ -74,11 +74,14 @@ def test_exclude_path_with_old_setting():
     )
 
 
-def test_response_charset_missing_raises_5xx():
-    with pytest.raises(ResponseValidationError):
+def test_response_content_type_missing_raises_5xx():
+    with pytest.raises(ResponseValidationError) as excinfo:
         prepare_body(
-            Response(content_type='foo')
+            # there is no way to instantiate a Response object with no content type
+            mock.Mock(spec=Response, content_type=None),
         )
+
+    assert 'Content-Type must be set' in str(excinfo.value)
 
 
 @pytest.fixture

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py33,py34,py35,{py27,py35}-pyramid15,pep8
+envlist = py27,py33,py34,py35,{py27,py35}-pyramid15,pep8
 
 [testenv]
 deps =
@@ -26,7 +26,8 @@ commands =
 
 [flake8]
 exclude = .tox,*.egg
-max-complexity = 9
+# E501: line too long
+ignore = E501
 
 [testenv:docs]
 deps =


### PR DESCRIPTION
webob >= 1.7 does not return a content type, while we require one during validation. This makes sure pyramid_swagger as well as our tests run with both an older and a new version of webob. I ran the tests with the latest versions of webob (1.7.1) and pyramid (1.8.2), webob 1.6.3 and pyramid 1.7.1 as well as the latest version of webob and pyramid 1.7.1. pyramid 1.8 requires webob 1.7.

Fixes #185 