### PR TITLE
Fix boolean config values if read from ini file

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+2.3.2 (2017-XX-XX)
+++++++++++++++++++
+* Fix reading configuration values from INI files (see #182, #200)
+
 2.3.1 (2017-03-27)
 ++++++++++++++++++
 * Fix validation context for swagger 2.0 requests

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -14,16 +14,16 @@ A few relevant settings for your `Pyramid .ini file <http://docs.pylonsproject.o
 
         # `api_docs.json` for Swagger 1.2 and/or `swagger.json` for Swagger 2.0
         # directory location.
-        # Default: 'api_docs/'
-        pyramid_swagger.schema_directory = "schemas/live/here"
+        # Default: api_docs/
+        pyramid_swagger.schema_directory = schemas/live/here
 
         # Versions of Swagger to support. When both Swagger 1.2 and 2.0 are
         # supported, it is required for both schemas to define identical APIs.
         # In this dual-support mode, requests are validated against the Swagger
         # 2.0 schema only.
-        # Default: ['2.0']
-        # Supported versions: '1.2', '2.0'
-        pyramid_swagger.swagger_versions = ['2.0']
+        # Default: 2.0
+        # Supported versions: 1.2, 2.0
+        pyramid_swagger.swagger_versions = 2.0
 
         # Check the correctness of Swagger spec files.
         # Default: True
@@ -41,26 +41,26 @@ A few relevant settings for your `Pyramid .ini file <http://docs.pylonsproject.o
         # If disabled and an appropriate Swagger schema cannot be
         # found, then request and response validation is skipped.
         # Default: True
-        pyramid_swagger.enable_path_validation = True
+        pyramid_swagger.enable_path_validation = true
 
         # Use Python classes instead of dicts to represent models in incoming
         # requests.
         # Default: False
-        pyramid_swagger.use_models = False
+        pyramid_swagger.use_models = false
 
         # Exclude certain endpoints from validation. Takes a list of regular
         # expressions.
-        # Default: [r'^/static/?', r'^/api-docs/?, r'^/swagger.json']
-        pyramid_swagger.exclude_paths = [r'^/static/?', r'^/api-docs/?', r'^/swagger.json']
+        # Default: ^/static/? ^/api-docs/? ^/swagger.json
+        pyramid_swagger.exclude_paths = ^/static/? ^/api-docs/? ^/swagger.json
 
         # Exclude pyramid routes from validation. Accepts a list of strings
-        pyramid_swagger.exclude_routes = ['catchall', 'no-validation']
+        pyramid_swagger.exclude_routes = catchall no-validation
 
         # Path to contextmanager to handle request/response validation
         # exceptions. This should be a dotted python name as per
         # http://docs.pylonsproject.org/projects/pyramid/en/latest/glossary.html#term-dotted-python-name
         # Default: None
-        pyramid_swagger.validation_context_path = 'path.to.user.defined.contextmanager'
+        pyramid_swagger.validation_context_path = path.to.user.defined.contextmanager
 
         # Enable/disable automatic /api-doc endpoints to serve the swagger
         # schemas (true by default)
@@ -76,7 +76,7 @@ A few relevant settings for your `Pyramid .ini file <http://docs.pylonsproject.o
         # Note: It is not suggested to use it with Python 2.6. Known issues with
         #       os.path.relpath could affect the proper behaviour.
         # Default: False
-        pyramid_swagger.dereference_served_schema = False
+        pyramid_swagger.dereference_served_schema = false
 
 
 Note that, equivalently, you can add these settings during webapp configuration:

--- a/pyramid_swagger/tween.py
+++ b/pyramid_swagger/tween.py
@@ -632,8 +632,8 @@ def get_swagger_versions(settings):
     :return: list of strings. eg ['1.2', '2.0']
     :raises: ValueError when an unsupported Swagger version is encountered.
     """
-    swagger_versions = settings.get(
-        'pyramid_swagger.swagger_versions', DEFAULT_SWAGGER_VERSIONS)
+    swagger_versions = set(aslist(settings.get(
+        'pyramid_swagger.swagger_versions', DEFAULT_SWAGGER_VERSIONS)))
 
     if len(swagger_versions) == 0:
         raise ValueError('pyramid_swagger.swagger_versions is empty')

--- a/pyramid_swagger/tween.py
+++ b/pyramid_swagger/tween.py
@@ -18,6 +18,8 @@ from bravado_core.request import unmarshal_request
 from bravado_core.response import get_response_spec
 from bravado_core.response import OutgoingResponse
 from pyramid.interfaces import IRoutesMapper
+from pyramid.settings import asbool
+from pyramid.settings import aslist
 
 from pyramid_swagger.exceptions import RequestValidationError
 from pyramid_swagger.exceptions import ResponseValidationError
@@ -352,24 +354,24 @@ def load_settings(registry):
         swagger12_handler=build_swagger12_handler(
             registry.settings.get('pyramid_swagger.schema12')),
         swagger20_handler=build_swagger20_handler(),
-        validate_request=registry.settings.get(
+        validate_request=asbool(registry.settings.get(
             'pyramid_swagger.enable_request_validation',
-            True
-        ),
-        validate_response=registry.settings.get(
+            True,
+        )),
+        validate_response=asbool(registry.settings.get(
             'pyramid_swagger.enable_response_validation',
-            True
-        ),
-        validate_path=registry.settings.get(
+            True,
+        )),
+        validate_path=asbool(registry.settings.get(
             'pyramid_swagger.enable_path_validation',
-            True
-        ),
+            True,
+        )),
         exclude_paths=get_exclude_paths(registry),
-        exclude_routes=set(registry.settings.get(
+        exclude_routes=set(aslist(registry.settings.get(
             'pyramid_swagger.exclude_routes',
-        ) or []),
-        prefer_20_routes=set(registry.settings.get(
-            'pyramid_swagger.prefer_20_routes',) or []),
+        ) or [])),
+        prefer_20_routes=set(aslist(registry.settings.get(
+            'pyramid_swagger.prefer_20_routes') or [])),
     )
 
 

--- a/tests/acceptance/app/config.ini
+++ b/tests/acceptance/app/config.ini
@@ -3,6 +3,8 @@ use = call:tests.acceptance.app:main
 pyramid_swagger.enable_request_validation = true
 pyramid_swagger.enable_response_validation = false
 pyramid_swagger.enable_path_validation = true
-pyramid_swagger.exclude_routes = /undefined/first /undefined/second
+pyramid_swagger.exclude_routes = /undefined/first
+                                 /undefined/second
 pyramid_swagger.prefer_20_routes = /sample
 pyramid_swagger.schema_directory = tests/sample_schemas/good_app
+pyramid_swagger.swagger_versions = 1.2 2.0

--- a/tests/acceptance/app/config.ini
+++ b/tests/acceptance/app/config.ini
@@ -1,0 +1,8 @@
+[app:main]
+use = call:tests.acceptance.app:main
+pyramid_swagger.enable_request_validation = true
+pyramid_swagger.enable_response_validation = false
+pyramid_swagger.enable_path_validation = true
+pyramid_swagger.exclude_routes = /undefined/first /undefined/second
+pyramid_swagger.prefer_20_routes = /sample
+pyramid_swagger.schema_directory = tests/sample_schemas/good_app

--- a/tests/acceptance/config_ini_test.py
+++ b/tests/acceptance/config_ini_test.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+import os.path
+
+import pytest
+from pyramid.paster import get_appsettings
+from webtest import TestApp as App
+
+from .app import main
+from pyramid_swagger.tween import load_settings
+
+
+@pytest.fixture
+def ini_app():
+    settings = get_appsettings(os.path.join(os.path.dirname(__file__), 'app', 'config.ini'), name='main')
+    return App(main({}, **settings))
+
+
+def test_load_ini_settings(ini_app):
+    registry = ini_app.app.registry
+    settings = load_settings(registry)
+
+    # Make sure these settings are booleans
+    assert settings.validate_request is True
+    assert settings.validate_response is False
+    assert settings.validate_path is True
+    assert settings.exclude_routes == set(['/undefined/first', '/undefined/second'])
+    assert settings.prefer_20_routes == set(['/sample'])

--- a/tests/acceptance/config_ini_test.py
+++ b/tests/acceptance/config_ini_test.py
@@ -23,5 +23,5 @@ def test_load_ini_settings(ini_app):
     assert settings.validate_request is True
     assert settings.validate_response is False
     assert settings.validate_path is True
-    assert settings.exclude_routes == set(['/undefined/first', '/undefined/second'])
-    assert settings.prefer_20_routes == set(['/sample'])
+    assert settings.exclude_routes == {'/undefined/first', '/undefined/second'}
+    assert settings.prefer_20_routes == {'/sample'}

--- a/tests/acceptance/config_ini_test.py
+++ b/tests/acceptance/config_ini_test.py
@@ -6,6 +6,7 @@ from pyramid.paster import get_appsettings
 from webtest import TestApp as App
 
 from .app import main
+from pyramid_swagger.tween import get_swagger_versions
 from pyramid_swagger.tween import load_settings
 
 
@@ -25,3 +26,9 @@ def test_load_ini_settings(ini_app):
     assert settings.validate_path is True
     assert settings.exclude_routes == {'/undefined/first', '/undefined/second'}
     assert settings.prefer_20_routes == {'/sample'}
+
+
+def test_get_swagger_versions(ini_app):
+    settings = ini_app.app.registry.settings
+    swagger_versions = get_swagger_versions(settings)
+    assert swagger_versions == {'1.2', '2.0'}

--- a/tests/tween_test.py
+++ b/tests/tween_test.py
@@ -238,7 +238,7 @@ def test_get_op_for_request_not_found_when_no_match_in_swagger_spec():
 def test_get_swagger_versions_success():
     for versions in (['1.2'], ['2.0'], ['1.2', '2.0']):
         settings = {'pyramid_swagger.swagger_versions': versions}
-        assert versions == get_swagger_versions(settings)
+        assert set(versions) == get_swagger_versions(settings)
 
 
 def test_get_swagger_versions_empty():


### PR DESCRIPTION
Use the pyramid `asbool` and `aslist`[functions](http://docs.pylonsproject.org/projects/pyramid/en/latest/api/settings.html) when reading config values. This branch now includes tests to confirm that settings are read correctly as well as another fix for reading the supported swagger versions, which is read in a different function.

Fixes #182, #200