### PR TITLE
Fix broken exclude_path acceptance test

### DIFF
--- a/tests/acceptance/app/__init__.py
+++ b/tests/acceptance/app/__init__.py
@@ -31,6 +31,11 @@ def sample(request):
     return {}
 
 
+@view_config(route_name='swagger_undefined', renderer='json')
+def swagger_undefined(request):
+    return {}
+
+
 def main(global_config, **settings):
     """ Very basic pyramid app """
     config = Configurator(settings=settings)
@@ -52,6 +57,7 @@ def main(global_config, **settings):
     config.add_route('sample_post', '/sample')
     config.include(include_samples, route_prefix='/sample')
     config.add_route('throw_400', '/throw_400')
+    config.add_route('swagger_undefined', '/undefined/path')
 
     config.scan()
     return config.make_wsgi_app()

--- a/tests/acceptance/request_test.py
+++ b/tests/acceptance/request_test.py
@@ -100,9 +100,17 @@ def test_200_if_request_arg_types_are_not_strings(test_app):
 
 def test_400_if_path_not_in_swagger(test_app):
     assert test_app.get(
-        '/does_not_exist',
+        '/undefined/path',
         expect_errors=True,
     ).status_code == 400
+
+
+def test_200_skip_validation_with_excluded_path():
+    app = test_app(
+        request=Mock(spec=FixtureRequest, param=['2.0']),
+        **{'pyramid_swagger.exclude_paths': [r'^/undefined/path']}
+    )
+    assert app.get('/undefined/path').status_code == 200
 
 
 def test_400_if_request_arg_is_wrong_type_but_not_castable(test_app):
@@ -203,14 +211,6 @@ def test_200_with_required_header(test_app):
         expect_errors=True,
     )
     assert response.status_code == 200
-
-
-def test_200_skip_validation_with_excluded_path():
-    app = test_app(
-        request=Mock(spec=FixtureRequest, param=['2.0']),
-        **{'pyramid_swagger.exclude_paths': [r'^/sample/?']}
-    )
-    assert app.get('/sample/test_request/resource').status_code == 200
 
 
 def test_200_skip_validation_when_disabled():


### PR DESCRIPTION
The test was not testing anything, as the path requested is defined in the swagger spec. We now register a Pyramid route that is not defined in the spec, and have two tests that do the same thing but assert different results depending on the config value.

Fixes #64.