### PR TITLE
Unpin tox version used by travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ env:
 - TOXENV=py34
 - TOXENV=py27-pyramid15
 - TOXENV=docs
-install: pip install tox==1.9.2 coveralls
+install: pip install tox coveralls
 script: tox
 after_success: coveralls


### PR DESCRIPTION
We're already using the latest `tox` when running tests locally, let's do the same for travis runs.