### PR TITLE
Use Python 3.5 for travis run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: python
 env:
 - TOXENV=py27
-- TOXENV=py34
+- TOXENV=py35
 - TOXENV=py27-pyramid15
 - TOXENV=docs
 install: pip install tox==1.9.2 coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 sudo: false
 language: python
-env:
-- TOXENV=py27
-- TOXENV=py35
-- TOXENV=py27-pyramid15
-- TOXENV=docs
+matrix:
+    include:
+    - env: TOXENV=py27
+    - python: "3.5"
+      env: TOXENV=py35
+    - env: TOXENV=py27-pyramid15
+    - env: TOXENV=docs
 install: pip install tox==1.9.2 coveralls
 script: tox
 after_success: coveralls


### PR DESCRIPTION
I should have done this as part of the last PR, but unfortunately I noticed it too late. Python 3.5 seems to become somewhat the "standard" Python 3 version, with a lot of long-term supported distributions shipping it. Let's use it as the version we test against on travis.