### PR TITLE
Fix tests due to bravado core flattening update

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     packages=find_packages(exclude=["contrib", "docs", "tests*"]),
     include_package_data=True,
     install_requires=[
-        'bravado-core >= 4.8.0, != 4.8.3',
+        'bravado-core >= 4.8.4',
         'jsonschema',
         'pyramid',
         'simplejson',

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     packages=find_packages(exclude=["contrib", "docs", "tests*"]),
     include_package_data=True,
     install_requires=[
-        'bravado-core >= 4.8.0',
+        'bravado-core >= 4.8.0, != 4.8.3',
         'jsonschema',
         'pyramid',
         'simplejson',

--- a/tests/sample_schemas/relative_ref/dereferenced_swagger.json
+++ b/tests/sample_schemas/relative_ref/dereferenced_swagger.json
@@ -1,25 +1,4 @@
 {
-    "definitions": {
-        "lfile:responses..common.json|..200": {
-            "description": "Return a standard_response",
-            "schema": {
-                "additionalProperties": false,
-                "properties": {
-                    "logging_info": {
-                        "type": "object"
-                    },
-                    "raw_response": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "raw_response",
-                    "logging_info"
-                ],
-                "type": "object"
-            }
-        }
-    },
     "host": "localhost:9999",
     "info": {
         "title": "Title was not specified",
@@ -44,7 +23,7 @@
                 "operationId": "no_models_get",
                 "responses": {
                     "200": {
-                        "$ref": "#/definitions/lfile:responses..common.json|..200"
+                        "$ref": "#/responses/lfile:responses..common.json|..200"
                     }
                 }
             }
@@ -60,7 +39,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/definitions/lfile:responses..common.json|..200"
+                        "$ref": "#/responses/lfile:responses..common.json|..200"
                     }
                 }
             }
@@ -69,6 +48,27 @@
     "produces": [
         "application/json"
     ],
+    "responses": {
+        "lfile:responses..common.json|..200": {
+            "description": "Return a standard_response",
+            "schema": {
+                "additionalProperties": false,
+                "properties": {
+                    "logging_info": {
+                        "type": "object"
+                    },
+                    "raw_response": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "raw_response",
+                    "logging_info"
+                ],
+                "type": "object"
+            }
+        }
+    },
     "schemes": [
         "http"
     ],


### PR DESCRIPTION
This PR is needed to fix tests failure related to a bug introduced by ``bravado-core`` ([Issue #190](https://github.com/Yelp/bravado-core/issues/190)).

The test update is needed because from ``bravado-core >= 4.8.3`` responses can be collected on top level ``responses`` property. 