### PR TITLE
Adding support of new Bravado param `include_missing_properties`

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -55,6 +55,11 @@ A few relevant settings for your `Pyramid .ini file <http://docs.pylonsproject.o
         # Default: False
         pyramid_swagger.use_models = false
 
+        # Set value for parameter defined in swagger schema to None if value was not provided.
+        # Skip parameter if value is missed and include_missing_properties is False.
+        # Default: True
+        pyramid_swagger.include_missing_properties = true
+
         # Exclude certain endpoints from validation. Takes a list of regular
         # expressions.
         # Default: ^/static/? ^/api-docs/? ^/swagger.json

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -55,8 +55,8 @@ A few relevant settings for your `Pyramid .ini file <http://docs.pylonsproject.o
         # Default: False
         pyramid_swagger.use_models = false
 
-        # Set value for parameter defined in swagger schema to None if value was not provided.
-        # Skip parameter if value is missed and include_missing_properties is False.
+        # Set value for property defined in swagger schema to None if value was not provided.
+        # Skip property if value is missed and include_missing_properties is False.
         # Default: True
         pyramid_swagger.include_missing_properties = true
 

--- a/pyramid_swagger/ingest.py
+++ b/pyramid_swagger/ingest.py
@@ -204,6 +204,7 @@ def create_bravado_core_config(settings):
             'validate_swagger_spec',
         'pyramid_swagger.use_models': 'use_models',
         'pyramid_swagger.user_formats': 'formats',
+        'pyramid_swagger.include_missing_properties': 'include_missing_properties',
     }
 
     bravado_core_config_defaults = {

--- a/tests/ingest_test.py
+++ b/tests/ingest_test.py
@@ -127,13 +127,15 @@ def test_create_bravado_core_config_non_empty():
         'pyramid_swagger.enable_swagger_spec_validation': True,
         'pyramid_swagger.use_models': True,
         'pyramid_swagger.user_formats': [some_format],
+        'pyramid_swagger.include_missing_properties': False,
     }
     expected_bravado_core_config = {
         'validate_requests': True,
         'validate_responses': False,
         'validate_swagger_spec': True,
         'use_models': True,
-        'formats': [some_format]
+        'formats': [some_format],
+        'include_missing_properties': False
     }
     bravado_core_config = create_bravado_core_config(pyramid_swagger_config)
     assert expected_bravado_core_config == bravado_core_config


### PR DESCRIPTION
In some cases we need to use [JSON Merge Patch Format](https://tools.ietf.org/html/rfc7386) for PATCH resource. If we need to update only person's last name we send `{'last_name': 'Name'}` ignoring other fields but current logic set `None` to all fields that weren't included into request. 
Bravado added special parameter `include_missing_properties` to handle such cases so it would be great to add support of this config property into Your library.

Default value is `True` so I updated test to handle `False` case.