### PR TITLE
Convert enable_api_doc_views to bool

### DIFF
--- a/pyramid_swagger/__init__.py
+++ b/pyramid_swagger/__init__.py
@@ -42,7 +42,8 @@ def includeme(config):
         under=pyramid.tweens.EXCVIEW
     )
 
-    if settings.get('pyramid_swagger.enable_api_doc_views', True):
+    if pyramid.settings.asbool(
+            settings.get('pyramid_swagger.enable_api_doc_views', True)):
         if SWAGGER_12 in swagger_versions:
             register_api_doc_endpoints(
                 config,


### PR DESCRIPTION
Previously, setting
pyramid_swagger.enable_api_doc_views = false
in a configuration .ini file would not disable the api_doc views,
because the string 'false' is truthy.

 - Convert the string-value of
   settings.get('pyramid_swagger.enable_api_doc_views', True)
   to a bool using pyramid.settings.asbool .
   (https://docs.pylonsproject.org/projects/pyramid/en/latest/api/settings.html)