### PR TITLE
bravado-core passthrough configs

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -97,6 +97,12 @@ A few relevant settings for your `Pyramid .ini file <http://docs.pylonsproject.o
         pyramid_swagger.dereference_served_schema = false
 
 
+.. note::
+
+    ``pyramid_swawgger`` uses a ``bravado_core.spec.Spec`` instance for handling swagger related details.
+    You can set `bravado-core config values <http://bravado-core.readthedocs.io/en/stable/config.html>`_ by adding a ``bravado-core.`` prefix to them.
+
+
 Note that, equivalently, you can add these settings during webapp configuration:
 
 .. code-block:: python

--- a/tests/ingest_test.py
+++ b/tests/ingest_test.py
@@ -8,6 +8,7 @@ import simplejson
 from pyramid_swagger.ingest import _load_resource_listing
 from pyramid_swagger.ingest import API_DOCS_FILENAME
 from pyramid_swagger.ingest import ApiDeclarationNotFoundError
+from pyramid_swagger.ingest import BRAVADO_CORE_CONFIG_PREFIX
 from pyramid_swagger.ingest import create_bravado_core_config
 from pyramid_swagger.ingest import generate_resource_listing
 from pyramid_swagger.ingest import get_resource_listing
@@ -120,23 +121,65 @@ def test_create_bravado_core_config_with_defaults():
     assert {'use_models': False} == create_bravado_core_config({})
 
 
-def test_create_bravado_core_config_non_empty():
-    some_format = mock.Mock(spec=SwaggerFormat)
+@pytest.fixture
+def bravado_core_formats():
+    return [mock.Mock(spec=SwaggerFormat)]
+
+
+@pytest.fixture
+def bravado_core_configs(bravado_core_formats):
+    return {
+        'validate_requests': True,
+        'validate_responses': False,
+        'validate_swagger_spec': True,
+        'use_models': True,
+        'formats': bravado_core_formats,
+        'include_missing_properties': False
+    }
+
+
+@mock.patch('pyramid_swagger.ingest.warnings')
+def test_create_bravado_core_config_non_empty_deprecated_configs(mock_warnings, bravado_core_formats, bravado_core_configs):
     pyramid_swagger_config = {
         'pyramid_swagger.enable_request_validation': True,
         'pyramid_swagger.enable_response_validation': False,
         'pyramid_swagger.enable_swagger_spec_validation': True,
         'pyramid_swagger.use_models': True,
-        'pyramid_swagger.user_formats': [some_format],
+        'pyramid_swagger.user_formats': bravado_core_formats,
         'pyramid_swagger.include_missing_properties': False,
     }
-    expected_bravado_core_config = {
-        'validate_requests': True,
-        'validate_responses': False,
-        'validate_swagger_spec': True,
-        'use_models': True,
-        'formats': [some_format],
-        'include_missing_properties': False
-    }
+
     bravado_core_config = create_bravado_core_config(pyramid_swagger_config)
-    assert expected_bravado_core_config == bravado_core_config
+
+    assert bravado_core_configs == bravado_core_config
+    # NOTE: the assertion is detailed and not defined by a constant because PYRAMID_SWAGGER_TO_BRAVADO_CORE_CONFIGS_MAPPING
+    # usage is deprecated and will eventually be removed in future versions
+    mock_warnings.warn.assert_called_once_with(
+        message='Configs '
+                'pyramid_swagger.enable_request_validation, pyramid_swagger.enable_response_validation, '
+                'pyramid_swagger.enable_swagger_spec_validation, pyramid_swagger.include_missing_properties, '
+                'pyramid_swagger.use_models, pyramid_swagger.user_formats '
+                'are deprecated, please use '
+                'bravado_core.validate_requests, bravado_core.validate_responses, '
+                'bravado_core.validate_swagger_spec, bravado_core.include_missing_properties, '
+                'bravado_core.use_models, bravado_core.formats '
+                'instead.',
+        category=DeprecationWarning,
+    )
+
+
+@mock.patch('pyramid_swagger.ingest.warnings')
+def test_create_bravado_core_config_with_passthrough_configs(mock_warnings, bravado_core_formats, bravado_core_configs):
+    pyramid_swagger_config = {
+        '{}validate_requests'.format(BRAVADO_CORE_CONFIG_PREFIX): True,
+        '{}validate_responses'.format(BRAVADO_CORE_CONFIG_PREFIX): False,
+        '{}validate_swagger_spec'.format(BRAVADO_CORE_CONFIG_PREFIX): True,
+        '{}use_models'.format(BRAVADO_CORE_CONFIG_PREFIX): True,
+        '{}formats'.format(BRAVADO_CORE_CONFIG_PREFIX): bravado_core_formats,
+        '{}include_missing_properties'.format(BRAVADO_CORE_CONFIG_PREFIX): False
+    }
+
+    bravado_core_config = create_bravado_core_config(pyramid_swagger_config)
+
+    assert bravado_core_configs == bravado_core_config
+    assert not mock_warnings.warn.called


### PR DESCRIPTION
Fixes #220.

This PR deprecates (with a warning only for now) the usage of ``pyramid_swagger.xxx`` configs for the configuration of the underlying ``bravado_core`` instance.
In order to _trick_ bravado-core related configs ``bravado_core.xxx`` should be used instead.