### PR TITLE
Fixes #222 - Add "raw_bytes" property to OutgoingResponse usages for msgpack support

### DIFF
--- a/pyramid_swagger/tween.py
+++ b/pyramid_swagger/tween.py
@@ -298,6 +298,10 @@ class PyramidSwaggerResponse(OutgoingResponse):
         return self.response.headers
 
     @property
+    def raw_bytes(self):
+        return self.response.body
+
+    @property
     def text(self):
 
         # Treating webob.Response carefully: first check if there's a

--- a/tests/tween_test.py
+++ b/tests/tween_test.py
@@ -381,7 +381,7 @@ def test_request_properties():
 def test_response_properties():
     root_response = Response(
         headers={"X-Some-Special-Header": "foobar"},
-        body='{"myKey": 42}'
+        body=b'{"myKey": 42}'
     )
     # these must be set for the "text" attribute of webob.Response to be
     # readable, and setting them in the constructor gets into a conflict
@@ -390,6 +390,7 @@ def test_response_properties():
     root_response.charset = 'utf8'
     response = PyramidSwaggerResponse(root_response)
     assert '{"myKey": 42}' == response.text
+    assert b'{"myKey": 42}' == response.raw_bytes
     assert "foobar" == response.headers["X-Some-Special-Header"]
     assert 'application/json' == response.content_type
 


### PR DESCRIPTION
See https://github.com/Yelp/bravado-core/pull/216 for context

This commit will be required to use the newest version of bravado-core once that PR is merged