### PR TITLE
Gracefully handle operation attribute not set in request during rendering

### DIFF
--- a/pyramid_swagger/renderer.py
+++ b/pyramid_swagger/renderer.py
@@ -17,7 +17,7 @@ class PyramidSwaggerRendererFactory(object):
 
     def _marshal_object(self, request, response_object):
         # operation attribute is injected by validator_tween in case the endpoint is served by Swagger 2.0 specs
-        operation = getattr(request, 'operation')
+        operation = getattr(request, 'operation', None)
 
         if not operation:
             # If the request is not served by Swagger2.0 endpoint _marshal_object is NO_OP


### PR DESCRIPTION
During an investigation over a pyramid-swagger instance serving Swagger 1.2 specs I've noticed that in case `pyramid_swagger_rendered` is used to render a response of a Swagger 1.2 endpoint it fails with `AttributeError` as `operation` attribute is not injected into request object for those type of endpoints.

I've noticed that the issue is caused by the fact that `getattr` is not using a default value to prevent exception to be raised.

NOTE: The renderer was defined keeping in consideration that in case of swagger1.2 endpoints the renderer should react as NOOP (`if not operation: return response_object`)
