### PR TITLE
pyramid-swagger should not assume that body is present

### DIFF
--- a/pyramid_swagger/load_schema.py
+++ b/pyramid_swagger/load_schema.py
@@ -195,7 +195,7 @@ class SchemaValidator(object):
         """Validate a :class:`dict` of values. If `self.schema` is falsy this
         is a noop.
         """
-        if not self.schema:
+        if not self.schema or (values is None and not self.schema.get('required', False)):
             return
         self.validator.validate(values)
 

--- a/pyramid_swagger/tween.py
+++ b/pyramid_swagger/tween.py
@@ -268,7 +268,10 @@ class PyramidSwaggerRequest(IncomingRequest):
         return result
 
     def json(self, **kwargs):
-        return getattr(self.request, 'json_body', {})
+        if self.request.is_body_readable:
+            return getattr(self.request, 'json_body', {})
+        else:
+            return None
 
 
 class PyramidSwaggerResponse(OutgoingResponse):

--- a/tests/acceptance/app/__init__.py
+++ b/tests/acceptance/app/__init__.py
@@ -47,6 +47,11 @@ def date_view(request):
     return request.swagger_data['body']
 
 
+@view_config(route_name='post_endpoint_with_optional_body', request_method='POST', renderer='pyramid_swagger')
+def post_endpoint_with_optional_body(request):
+    return request.content_length
+
+
 @view_config(route_name='swagger_undefined', renderer='json')
 def swagger_undefined(request):
     return {}
@@ -77,6 +82,7 @@ def main(global_config, **settings):
 
     config.add_route('echo_date', '/echo_date')
     config.add_route('echo_date_json_renderer', '/echo_date_json_renderer')
+    config.add_route('post_endpoint_with_optional_body', '/post_endpoint_with_optional_body')
 
     config.scan()
     return config.make_wsgi_app()

--- a/tests/ingest_test.py
+++ b/tests/ingest_test.py
@@ -57,7 +57,7 @@ def test_get_swagger_schema_default():
     }
 
     swagger_schema = get_swagger_schema(settings)
-    assert len(swagger_schema.pyramid_endpoints) == 5
+    assert len(swagger_schema.pyramid_endpoints) == 6
     assert swagger_schema.resource_validators
 
 
@@ -84,6 +84,7 @@ def test_generate_resource_listing():
             {'path': '/echo_date'},
             {'path': '/no_models'},
             {'path': '/other_sample'},
+            {'path': '/post_endpoint_with_optional_body'},
             {'path': '/sample'},
         ]
     }

--- a/tests/sample_schemas/good_app/api_docs.json
+++ b/tests/sample_schemas/good_app/api_docs.json
@@ -16,6 +16,10 @@
         {
             "path": "/echo_date",
             "description": "Echoes the input body in the response. Endpoint used for verifying PyramidSwaggerRendererFactory"
+        },
+        {
+            "path": "/post_endpoint_with_optional_body",
+            "description": "Returns the request body length. Used to verify that optional body parameters are well handled"
         }
     ]
 }

--- a/tests/sample_schemas/good_app/post_endpoint_with_optional_body.json
+++ b/tests/sample_schemas/good_app/post_endpoint_with_optional_body.json
@@ -1,0 +1,32 @@
+{
+  "apiVersion": "0.1",
+  "swaggerVersion": "1.2",
+  "basePath": "http://localhost:9999/post_endpoint_with_optional_body",
+  "apis": [
+    {
+      "path": "/post_endpoint_with_optional_body",
+      "operations": [
+        {
+          "method": "POST",
+          "nickname": "post_endpoint_with_optional_body",
+          "type": "integer",
+          "parameters": [
+            {
+              "name": "body",
+              "paramType": "body",
+              "required": false,
+              "type": "object"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "models": {
+    "object": {
+      "id": "object",
+      "properties": {
+      }
+    }
+  }
+}

--- a/tests/sample_schemas/good_app/swagger.json
+++ b/tests/sample_schemas/good_app/swagger.json
@@ -23,6 +23,7 @@
           {
             "in": "body",
             "name": "body",
+            "required": true,
             "schema": {
               "$ref": "#/definitions/object_with_formats"
             }
@@ -39,6 +40,30 @@
         "operationId": "echo_date"
       }
     },
+    "/post_endpoint_with_optional_body": {
+      "post": {
+        "description": "Returns the request body length. Used to verify that optional body parameters are well handled",
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": false,
+            "schema": {
+              "type": "object"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "HTTP/200 OK. Return request body length",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        },
+        "operationId": "post_endpoint_with_optional_body"
+      }
+    },
     "/echo_date_json_renderer": {
       "post": {
         "description": "This endpoint is used in tests/acceptance/request_test.py and requires to be identical to /echo_date endpoint",
@@ -46,6 +71,7 @@
           {
             "in": "body",
             "name": "body",
+            "required": true,
             "schema": {
               "$ref": "#/definitions/object_with_formats"
             }


### PR DESCRIPTION
While working with endpoints which specify an optional body parameter pyramid-swagger raises a really ugly exception related to the fact that the library is trying to decode an empty body.
The raised exception looks like
```
self = <json.decoder.JSONDecoder object at 0x10e811198>, s = '', idx = 0

    def raw_decode(self, s, idx=0):
        """Decode a JSON document from ``s`` (a ``str`` beginning with
            a JSON document) and return a 2-tuple of the Python
            representation and the index in ``s`` where the document ended.

            This can be used to decode a JSON document from a string that may
            have extraneous data at the end.

            """
        try:
            obj, end = self.scan_once(s, idx)
        except StopIteration as err:
>           raise JSONDecodeError("Expecting value", s, err.value) from None
E           json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```
NOTE: the stacktrace above is obtained by running `python -m pytest tests/acceptance/request_test.py::test_post_endpoint_with_optional_body[1.2-body0]` on sha `79a5cfa2c57b02dbbe351ffc5eaa48b157542f88`

In order to prevent unwanted JSON decoding we need to ensure that the `PyramidSwaggerRequest` will not call `self.request.json_body` if the body is emtpy.

While writing checking tests I've noticed that object validation fails either on Swagger 1.2 and Swagger  2.0.
Swagger1.2 validation is handled by this library and the fix is alraedy present on this PR (otherwise tests would have been red), while the Swagger2.0 validation is performed by bravado-core.

A PR will be opened for that project too, but in the mean time Swagger 2.0 allows us to disable request validation if needed.
