### PR TITLE
Remove warnings related to deprecated pyramid_swagger configurations

### DIFF
--- a/pyramid_swagger/ingest.py
+++ b/pyramid_swagger/ingest.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 import glob
 import os.path
-import warnings
 
 import simplejson
 from bravado_core.spec import build_http_handlers
@@ -215,27 +214,13 @@ def create_bravado_core_config(settings):
     }
 
     configs = {
-        'use_models': False
+        'use_models': False,
     }
-
-    bravado_core_configs_from_pyramid_swagger_configs = {
+    configs.update({
         bravado_core_key: settings[pyramid_swagger_key]
         for pyramid_swagger_key, bravado_core_key in iteritems(config_keys)
         if pyramid_swagger_key in settings
-    }
-    if bravado_core_configs_from_pyramid_swagger_configs:
-        warnings.warn(
-            message='Configs {old_configs} are deprecated, please use {new_configs} instead.'.format(
-                old_configs=', '.join(k for k, v in sorted(iteritems(config_keys))),
-                new_configs=', '.join(
-                    '{}{}'.format(BRAVADO_CORE_CONFIG_PREFIX, v)
-                    for k, v in sorted(iteritems(config_keys))
-                ),
-            ),
-            category=DeprecationWarning,
-        )
-        configs.update(bravado_core_configs_from_pyramid_swagger_configs)
-
+    })
     configs.update({
         key.replace(BRAVADO_CORE_CONFIG_PREFIX, ''): value
         for key, value in iteritems(settings)

--- a/pyramid_swagger/load_schema.py
+++ b/pyramid_swagger/load_schema.py
@@ -184,7 +184,7 @@ class SchemaValidator(object):
 
     :param schema: a :class:`dict` jsonschema that was used by the
         validator
-    :param valdiator: a Validator which a func:`validate` method
+    :param validator: a Validator which a func:`validate` method
         for validating a field from a request or response. This
         will often be a :class:`jsonschema.validator.Validator`.
     """

--- a/tests/acceptance/api_test.py
+++ b/tests/acceptance/api_test.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
+import os
+
 import pytest
 from webtest import TestApp as App
 
@@ -10,7 +12,7 @@ from tests.acceptance.app import main
 @pytest.fixture
 def settings():
     return {
-        'pyramid_swagger.schema_directory': 'tests/sample_schemas/good_app/',
+        'pyramid_swagger.schema_directory': os.path.join('tests', 'sample_schemas', 'good_app'),
         'pyramid_swagger.enable_swagger_spec_validation': False,
     }
 

--- a/tests/ingest_test.py
+++ b/tests/ingest_test.py
@@ -141,9 +141,8 @@ def bravado_core_configs(bravado_core_formats):
     }
 
 
-@mock.patch('pyramid_swagger.ingest.warnings')
 def test_create_bravado_core_config_non_empty_deprecated_configs(
-    mock_warnings, bravado_core_formats, bravado_core_configs,
+    bravado_core_formats, bravado_core_configs,
 ):
     pyramid_swagger_config = {
         'pyramid_swagger.enable_request_validation': True,
@@ -157,25 +156,9 @@ def test_create_bravado_core_config_non_empty_deprecated_configs(
     bravado_core_config = create_bravado_core_config(pyramid_swagger_config)
 
     assert bravado_core_configs == bravado_core_config
-    # NOTE: the assertion is detailed and not defined by a constant because
-    # PYRAMID_SWAGGER_TO_BRAVADO_CORE_CONFIGS_MAPPING usage is deprecated
-    # and will eventually be removed in future versions
-    mock_warnings.warn.assert_called_once_with(
-        message='Configs '
-                'pyramid_swagger.enable_request_validation, pyramid_swagger.enable_response_validation, '
-                'pyramid_swagger.enable_swagger_spec_validation, pyramid_swagger.include_missing_properties, '
-                'pyramid_swagger.use_models, pyramid_swagger.user_formats '
-                'are deprecated, please use '
-                'bravado_core.validate_requests, bravado_core.validate_responses, '
-                'bravado_core.validate_swagger_spec, bravado_core.include_missing_properties, '
-                'bravado_core.use_models, bravado_core.formats '
-                'instead.',
-        category=DeprecationWarning,
-    )
 
 
-@mock.patch('pyramid_swagger.ingest.warnings')
-def test_create_bravado_core_config_with_passthrough_configs(mock_warnings, bravado_core_formats, bravado_core_configs):
+def test_create_bravado_core_config_with_passthrough_configs(bravado_core_formats, bravado_core_configs):
     pyramid_swagger_config = {
         '{}validate_requests'.format(BRAVADO_CORE_CONFIG_PREFIX): True,
         '{}validate_responses'.format(BRAVADO_CORE_CONFIG_PREFIX): False,
@@ -188,4 +171,3 @@ def test_create_bravado_core_config_with_passthrough_configs(mock_warnings, brav
     bravado_core_config = create_bravado_core_config(pyramid_swagger_config)
 
     assert bravado_core_configs == bravado_core_config
-    assert not mock_warnings.warn.called


### PR DESCRIPTION
The goal of this PR is to reduce the amount of warnings related to pyramid swagger configurations.

#221 added warnings in case of presence of `pyramid_swagger` configuration that are mainly used for configuring `bravado-core`.
The warning mentions that keys like `pyramid_swagger.enable_request_validation` are deprecated, but the codebase does still use them.
This means that users following the warning would replace `pyramid_swagger.enable_request_validation` with `bravado_core.validate_requests` but the tweens needed for the validation are added only if `pyramid_swagger.enable_request_validation` is set.

As pyramid-swagger does still support Swagger1.2, it would be odd to use `bravado_core.validate_requests` as Swagger1.2 does not actually use bravado-core.

