### PR TITLE
Ensure http 401 in case of missing security

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ matrix:
       env: TOXENV=py27
     - python: "3.5"
       env: TOXENV=py35
+    - python: "3.6"
+      env: TOXENV=py36
     - python: "2.7"
       env: TOXENV=py27-pyramid15
     - python: "3.6"

--- a/pyramid_swagger/exceptions.py
+++ b/pyramid_swagger/exceptions.py
@@ -7,12 +7,19 @@ import six
 from pyramid.httpexceptions import HTTPBadRequest
 from pyramid.httpexceptions import HTTPInternalServerError
 from pyramid.httpexceptions import HTTPNotFound
+from pyramid.httpexceptions import HTTPUnauthorized
 
 
 class RequestValidationError(HTTPBadRequest):
     def __init__(self, *args, **kwargs):
         self.child = kwargs.pop('child', None)
         super(RequestValidationError, self).__init__(*args, **kwargs)
+
+
+class RequestAuthenticationError(HTTPUnauthorized):
+    def __init__(self, *args, **kwargs):
+        self.child = kwargs.pop('child', None)
+        super(RequestAuthenticationError, self).__init__(*args, **kwargs)
 
 
 class PathNotFoundError(HTTPNotFound):

--- a/tests/acceptance/app/__init__.py
+++ b/tests/acceptance/app/__init__.py
@@ -27,6 +27,7 @@ def standard(request, path_arg):
 @view_config(route_name='get_with_non_string_query_args', renderer='json')
 @view_config(route_name='post_with_primitive_body', renderer='json')
 @view_config(route_name='sample_header', renderer='json')
+@view_config(route_name='sample_authentication', renderer='json')
 @view_config(route_name='sample_post', renderer='json')
 @view_config(route_name='post_with_form_params', renderer='json')
 @view_config(route_name='post_with_file_upload', renderer='json')
@@ -92,3 +93,4 @@ def main(global_config, **settings):
 
 def include_samples(config):
     config.add_route('sample_header', '/header')
+    config.add_route('sample_authentication', '/authentication')

--- a/tests/acceptance/request_test.py
+++ b/tests/acceptance/request_test.py
@@ -306,3 +306,12 @@ def test_request_validation_context():
         **{'pyramid_swagger.validation_context_path': validation_ctx_path})
     response = app.get('/get_with_non_string_query_args', params={})
     assert response.status_code == 206
+
+
+def test_request_to_authenticated_endpoint_without_authentication():
+    app = build_test_app(swagger_versions=['2.0'])
+    response = app.get(
+        '/sample/authentication',
+        expect_errors=True,
+    )
+    assert response.status_code == 401

--- a/tests/sample_schemas/good_app/swagger.json
+++ b/tests/sample_schemas/good_app/swagger.json
@@ -173,6 +173,20 @@
         ]
       }
     },
+    "/sample/authentication": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "No response was specified"
+          }
+        },
+        "description": "",
+        "operationId": "sample_authentication",
+        "security": [
+          {"AuthToken": []}
+        ]
+      }
+    },
     "/sample": {
       "get": {
         "responses": {
@@ -380,6 +394,14 @@
           ]
         }
       }
+    }
+  },
+  "securityDefinitions": {
+    "AuthToken": {
+      "description": "Dummy Auth Token",
+      "in": "header",
+      "name": "X-Auth-Token",
+      "type": "apiKey"
     }
   }
 }


### PR DESCRIPTION
While using pyramid-swagger for a personal project I've noticed that:
_missing authentication information specified in the `security` section of the swagger specs results in a HTTP/400 response_

This was caused by the fact that call to `bravado_core.request.unmarshal_request` is wrapped to reraise `SwaggerMappingError` as `RequestValidationError`.
In the specific case of missing authentication information, bravado_core raises a `SwaggerSecurityValidationError` exception.

The goal of this PR is to catch such exception and to re-raise it as `RequestAuthenticationError` (which extends the base `HTTPUnauthorized`)