### PR TITLE
Reduce usage of deprecated methods

### DIFF
--- a/pyramid_swagger/api.py
+++ b/pyramid_swagger/api.py
@@ -233,7 +233,7 @@ class YamlRendererFactory(object):
     def __call__(self, value, system):
         response = system['request'].response
         response.headers['Content-Type'] = 'application/x-yaml; charset=UTF-8'
-        return yaml.dump(value).encode('utf-8')
+        return yaml.safe_dump(value).encode('utf-8')
 
 
 def build_swagger_20_swagger_schema_views(config):

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'bravado-core >= 4.8.4',
-        'jsonschema',
+        'jsonschema >= 3.0.0',
         'pyramid',
         'simplejson',
     ],

--- a/tests/acceptance/recursive_app_test.py
+++ b/tests/acceptance/recursive_app_test.py
@@ -13,7 +13,7 @@ from tests.acceptance.app import main
 
 DESERIALIZERS = {
     'json': lambda r: json.loads(r.body.decode('utf-8')),
-    'yaml': lambda r: yaml.load(BytesIO(r.body)),
+    'yaml': lambda r: yaml.safe_load(BytesIO(r.body)),
 }
 
 

--- a/tests/acceptance/relative_ref_test.py
+++ b/tests/acceptance/relative_ref_test.py
@@ -16,7 +16,7 @@ from tests.acceptance.app import main
 
 DESERIALIZERS = {
     'json': lambda r: json.loads(r.body.decode('utf-8')),
-    'yaml': lambda r: yaml.load(BytesIO(r.body)),
+    'yaml': lambda r: yaml.safe_load(BytesIO(r.body)),
 }
 
 

--- a/tests/acceptance/yaml_test.py
+++ b/tests/acceptance/yaml_test.py
@@ -87,7 +87,7 @@ def validate_json_response(response, expected_dict):
 
 def validate_yaml_response(response, expected_dict):
     assert response.headers['content-type'] == 'application/x-yaml; charset=UTF-8'
-    assert _strip_xmodel(yaml.load(response.body)) == expected_dict
+    assert _strip_xmodel(yaml.safe_load(response.body)) == expected_dict
 
 
 def _rewrite_ref(ref, schema_format):
@@ -122,7 +122,7 @@ def test_swagger_json_api_doc_route(testapp_with_base64, test_file, schema_forma
 
     fname = 'tests/sample_schemas/yaml_app/%s.yaml' % test_file
     with open(fname, 'r') as f:
-        expected_schema = yaml.load(f)
+        expected_schema = yaml.safe_load(f)
 
     _recursively_rewrite_refs(expected_schema, schema_format)
 

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -84,7 +84,7 @@ def test_resolve_nested_refs():
     """
     os.environ["PYTHONHASHSEED"] = str(1)
     with open('tests/sample_schemas/nested_defns/swagger.yaml') as swagger_spec:
-        spec_dict = yaml.load(swagger_spec)
+        spec_dict = yaml.safe_load(swagger_spec)
     spec = Spec.from_dict(spec_dict, '')
     assert spec.flattened_spec
 
@@ -108,7 +108,7 @@ def test_extenal_refs_no_empty_keys():
     keys swagger specs.
     """
     with open('tests/sample_schemas/external_refs/swagger.json') as swagger_spec:
-        spec_dict = yaml.load(swagger_spec)
+        spec_dict = yaml.safe_load(swagger_spec)
     path = 'file:' + os.getcwd() + '/tests/sample_schemas/external_refs/swagger.json'
     spec = Spec.from_dict(spec_dict, path)
     flattened_spec = spec.flattened_spec


### PR DESCRIPTION
The goal of this PR is to reduce the amount of errors returned by the usage of deprecated functions.

I've addressed the two families of warnings:
 1. yaml related -> replaced `yaml.(load|dump)` with `yaml.safe_(load|dump)`
 2. jsonschema related -> updated `SchemaValidator.from_schema` logic to use a non deprecated approach to build the validator instance
    NOTE: this requires jsonschema>=3