### PR TITLE
Convert bool values from a .ini file

### DIFF
--- a/pyramid_swagger/__init__.py
+++ b/pyramid_swagger/__init__.py
@@ -5,6 +5,7 @@ Import this module to add the validation tween to your pyramid app.
 from __future__ import absolute_import
 
 import pyramid
+from pyramid.settings import asbool
 
 from pyramid_swagger.api import build_swagger_20_swagger_schema_views
 from pyramid_swagger.api import register_api_doc_endpoints
@@ -47,7 +48,7 @@ def includeme(config):
 
     config.add_renderer('pyramid_swagger', PyramidSwaggerRendererFactory())
 
-    if settings.get('pyramid_swagger.enable_api_doc_views', True):
+    if asbool(settings.get('pyramid_swagger.enable_api_doc_views', True)):
         if SWAGGER_12 in swagger_versions:
             register_api_doc_endpoints(
                 config,

--- a/pyramid_swagger/ingest.py
+++ b/pyramid_swagger/ingest.py
@@ -8,6 +8,7 @@ import os.path
 import simplejson
 from bravado_core.spec import build_http_handlers
 from bravado_core.spec import Spec
+from pyramid.settings import asbool
 from six import iteritems
 from six.moves.urllib import parse as urlparse
 from six.moves.urllib.request import pathname2url
@@ -217,12 +218,13 @@ def create_bravado_core_config(settings):
         'use_models': False,
     }
     configs.update({
-        bravado_core_key: settings[pyramid_swagger_key]
+        bravado_core_key: (settings[pyramid_swagger_key] if bravado_core_key == 'formats'
+                           else asbool(settings[pyramid_swagger_key]))
         for pyramid_swagger_key, bravado_core_key in iteritems(config_keys)
         if pyramid_swagger_key in settings
     })
     configs.update({
-        key.replace(BRAVADO_CORE_CONFIG_PREFIX, ''): value
+        key.replace(BRAVADO_CORE_CONFIG_PREFIX, ''): asbool(value)
         for key, value in iteritems(settings)
         if key.startswith(BRAVADO_CORE_CONFIG_PREFIX)
     })


### PR DESCRIPTION
When I use a .ini file for configuration, some variables are passed to bravado-core in the form of str and always treated as `True`.
Since all variables except `formats` are boolean, they should be converted using `asbool()`: https://bravado-core.readthedocs.io/en/stable/config.html

The same thing happens for `enable_api_doc_views` in `__init__.py`, and thus I fixed.