### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -15,7 +15,7 @@ Creating your initial Swagger Schema can be intimidating but don't fear, it's no
 
 To create your first Swagger Schema, I encourage you to take a look at Swagger's official `PetStore example <http://petstore.swagger.io>`_. You can even see the raw JSON for the `Swagger Schema. <http://petstore.swagger.io/v2/swagger.json>`_ You'll notice that Swagger has a lot of details, but the core part of building a schema is documenting each endpoint's inputs and outputs.
 
-For your intial attempt, documenting an endpoint can be simplified to some basic components:
+For your initial attempt, documenting an endpoint can be simplified to some basic components:
 
 1. Documenting the core URI (e.g. /foo/bar)
 2. Documenting request parameters (in the path, in the query arguments, and in the query body)

--- a/pyramid_swagger/load_schema.py
+++ b/pyramid_swagger/load_schema.py
@@ -274,7 +274,7 @@ def extract_validatable_type(type_name, models):
     swagger-ui, they must not use a $ref to internal models.
 
     :returns: A key-value that jsonschema can validate. Key will be either
-        'type' or '$ref' as is approriate.
+        'type' or '$ref' as is appropriate.
     :rtype: dict
     """
     if type_name in models:


### PR DESCRIPTION
There are small typos in:
- docs/quickstart.rst
- pyramid_swagger/load_schema.py

Fixes:
- Should read `initial` rather than `intial`.
- Should read `appropriate` rather than `approriate`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md